### PR TITLE
docs: add CI badge and reflect Python 3.10-3.12 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A comprehensive, research-grade Python library for analyzing, modeling, and visu
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python Version](https://img.shields.io/badge/python-3.10--3.12-blue.svg)](https://www.python.org/downloads/)
+[![CI](https://github.com/DiogoRibeiro7/behavioral-sensing-research/actions/workflows/ci.yml/badge.svg)](https://github.com/DiogoRibeiro7/behavioral-sensing-research/actions/workflows/ci.yml)
 [![Documentation Status](https://readthedocs.org/projects/sensor-modeling/badge/?version=latest)](https://sensor-modeling.readthedocs.io/en/latest/?badge=latest)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17070042.svg)](https://doi.org/10.5281/zenodo.17070042)
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a GitHub Actions CI badge to the README and reflected support for Python 3.10–3.12. This makes build status and Python compatibility clear at a glance.

<sup>Written for commit a7a90d0e724a3e3c0fe085d3f2c402db4864eab1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

