### PR TITLE
Add architecture and design records

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,11 +36,22 @@ Implemented or substantially available:
 - Flask-based visualization app with authenticated upload workflow.
 - Zenodo, citation, and release metadata.
 
-## Delivered: Multimodal Ambient Sensing Platform
+## Capability Status by Theme
 
-The toolkit has been extended into a multimodal ambient-sensing platform on
-top of the existing modelling core. The following are implemented, tested and
-documented:
+Work is grouped by the outcome it unlocks. Each theme states what exists now
+and what is outstanding.
+
+### Existing capability (pre-multimodal core)
+
+Retained unchanged and still supported: CSV/JSON/HDF5 loading, gap-aware
+missing-data handling, Bernoulli autoregressive models, HMM variants,
+NHPP-PELT segmentation, change-point detectors, Granger and dependency-network
+analysis, LaTeX/HTML reporting, the Flask visualisation app, and the original
+CLI subcommands.
+
+### Foundation work
+
+Delivered:
 
 - A canonical, hardware-neutral observation model with boundary validation,
   unit conversion, duplicate collapse, out-of-order handling, late-arrival
@@ -50,28 +61,70 @@ documented:
   Inference reads declarations rather than sensor names.
 - Online sensor health estimation emitting a per-sensor evidence weight, with
   silence only treated as failure where a sensor promised to report.
+
+### Multimodal sensing
+
+Delivered:
+
 - A configurable continuous-time behavioural state ontology and a recursive
   multimodal Bayes filter over asynchronous, partially missing evidence, with
   explicit abstention.
 - Probabilistic occupancy estimation and uncertainty-aware attribution of
   ambient activity, using anonymous evidence only.
+
+### State inference
+
+Delivered: a configurable state ontology whose semantic claims stop where the
+evidence stops, with explicit abstention when confidence or sensor coverage is
+insufficient.
+
+### Personalisation
+
+Delivered:
+
 - Adaptive, robust, weekday-aware personal baselines distinguishing ordinary
   variability, weekly rhythm, temporary disturbance, persistent change,
   gradual drift, abrupt change, and insufficient data.
 - Restrained alerting with deduplication, rate limiting, explicit caveats, and
   a strict separation between system-health and behavioural findings.
+
+### Evaluation
+
+Delivered:
+
 - A synthetic household simulator with controlled ground truth, generatively
   independent of the inference model, plus separate fault injection.
 - Problem-appropriate evaluation metrics and a paired sensor-ablation
   framework reporting effect sizes and bootstrap intervals.
-- An incremental, snapshot-able pipeline suitable for edge deployment.
+
+### Online and edge processing
+
+Delivered: an incremental, bounded-memory, snapshot-able pipeline with a
+lateness buffer for stream reordering, independent of any UI or storage.
+
+### Clinical interoperability
+
+Delivered: a FHIR-style export that keeps measurements, derived features,
+inferred states and algorithmic alerts distinguishable through explicit
+provenance. Not a validated profile; see `docs/limitations.rst`.
+
+### Reproducible research
+
+Delivered:
+
 - A reproducible end-to-end command-line demonstration and ablation
   experiment.
 
-See `docs/ambient_architecture.rst`, `docs/inference.rst`,
-`docs/evaluation.rst` and `docs/limitations.rst`.
+User documentation: `docs/ambient_architecture.rst`, `docs/inference.rst`,
+`docs/evaluation.rst`, `docs/limitations.rst`.
 
-### Next priorities for this work
+Design record: `docs/MULTIMODAL_ARCHITECTURE.md`, `docs/RESEARCH_QUESTIONS.md`,
+`docs/SENSOR_DATA_MODEL.md`, `docs/UNCERTAINTY_MODEL.md`,
+`docs/EVALUATION_DESIGN.md`.
+
+### Longer-term research
+
+Outstanding, in priority order
 
 The single most important outstanding item is **validation against real
 annotated sensor data**. Every quantitative result currently comes from the

--- a/docs/EVALUATION_DESIGN.md
+++ b/docs/EVALUATION_DESIGN.md
@@ -1,0 +1,192 @@
+# Evaluation Design
+
+The experimental design, why each choice was made, and the threats to validity
+that remain. Implemented in `sensor_modeling.evaluation` and
+`sensor_modeling.simulation`.
+
+## Avoiding circular validation
+
+The simulator exists so inference can be scored against something known. That
+only works if the generative process differs from the inference model.
+
+| | Generative process | Inference model |
+| --- | --- | --- |
+| Structure | Stochastic daily **schedule** | Continuous-time **Markov chain** |
+| State duration | Drawn from per-activity distributions | Implicitly exponential |
+| Day structure | Wake, breakfast, outing, lunch, dinner, bed | None; the chain has no notion of a day |
+| Sensor firing | Per-room Poisson at activity-scaled rates | Poisson likelihood with declared rates |
+
+The estimator has to recover a schedule through a model that knows nothing
+about schedules. Had the two shared a generator, good results would prove only
+that the code can invert its own assumptions.
+
+Two guard tests enforce this and will fail if a future edit couples them:
+
+- `sensor_modeling.simulation.household` must not import `StateOntology`,
+  `transition_matrix` or `MultimodalBayesFilter`.
+- `sensor_modeling.online.pipeline` must not import `GroundTruth`, `Episode`
+  or anything from `simulation`.
+
+Ground truth is available only to evaluation code and is never passed to the
+pipeline.
+
+## Separating behaviour from degradation
+
+Fault injection is a separate module from behaviour generation. This is what
+makes paired comparison possible: the same simulated fortnight, once with a
+working wearable and once without, differs in exactly one thing.
+
+Degradations available: dropout, stuck sensors, random loss, wearable
+non-adherence, late arrival, duplication, per-source clock drift.
+`degrade()` returns the withheld records, so an evaluation reports how much
+evidence was actually missing rather than inferring it.
+
+## Metric selection
+
+Accuracy alone is close to meaningless here. The states are heavily
+imbalanced — a resident is asleep or quietly at home for most of the day — so
+a model that predicts `home_inactive` forever scores about 0.9 and knows
+nothing. Scoring only the argmax also discards the part of every output that
+matters.
+
+### State inference
+
+| Metric | Why |
+| --- | --- |
+| Balanced accuracy | Immune to the class imbalance that makes raw accuracy misleading |
+| Macro F1 | Penalises a model that achieves recall by over-predicting a class |
+| Log loss | Punishes confident errors far more than hedged ones |
+| Brier score | Proper scoring rule over the whole posterior |
+| Expected calibration error | Whether a stated confidence of 0.9 means anything |
+| Per-class recall | Exposes which states are being lost |
+| Transition timing | Whether changes are detected at the right moment, not merely counted |
+
+Transition matching is one-to-one within a tolerance: each inferred transition
+is consumed at most once, so a flickering model cannot match every truth by
+accident.
+
+### Abstention convention
+
+Stated once and applied everywhere: **a reported `UNKNOWN` is never correct**,
+because `UNKNOWN` is never a true label. It therefore costs recall.
+
+`selective_accuracy` (accuracy among committed estimates) and
+`abstention_rate` are reported alongside, so a model that declines usefully is
+distinguishable from one that is simply wrong. Without both numbers, either
+convention alone would mislead.
+
+### Attribution
+
+Precision, recall, F1 and calibration. Calibration is scored on the stated
+probability of the *predicted* class, so a confident "no visitor" is judged as
+strictly as a confident "visitor".
+
+### Change detection
+
+Detection delay, precision, recall, and **false positives per person-day** —
+the number that decides whether a system is usable in practice.
+
+A detection counts only if it falls at or after the true change and within
+`max_delay_days`. An alert raised *before* the change is a false positive, not
+early detection: a system that alarms before anything happened has alarmed at
+noise.
+
+Detection is scored on **alerts actually delivered**, not raw baseline
+verdicts. Deduplication and rate limiting sit between the two, and it is the
+delivered burden a carer experiences.
+
+### Reliability
+
+Performance is swept across 5%, 10%, 20% and 40% missingness, and separately
+under single-sensor failure, multi-sensor failure, wearable non-adherence,
+visitor contamination and total blackout. Calibration is reported at every
+point, because the failure mode of interest is confidence staying high while
+accuracy collapses.
+
+## Statistical design
+
+### Pairing is structural, not procedural
+
+One household is simulated per seed and shared by every configuration.
+`AblationReport.series()` **refuses** to return a series when a configuration
+is missing a seed, so an accidentally unpaired comparison fails loudly rather
+than quietly producing a plausible number.
+
+Why it matters: simulated households differ from each other far more than two
+sensor configurations differ on one household. An unpaired comparison buries a
+real effect under between-household variance.
+
+### Effect sizes and intervals, not p-values
+
+`paired_difference()` reports the mean paired difference, a bootstrap
+confidence interval, Cohen's *dz*, and a win/loss count. It deliberately does
+not report a p-value.
+
+With simulations, any effect can be made "significant" by running more seeds.
+The size of the difference and its uncertainty are the informative quantities;
+significance is a statement about how long the computer ran.
+
+**A caveat that cuts against the design.** Pairing removes between-household
+variance, which makes small differences detectable that an unpaired field
+study of the same size would not resolve. A detectable difference is not
+automatically an important one. Both the raw mean difference and the interval
+are reported so magnitude stays visible.
+
+## Ablation protocol
+
+Configurations are **registry subsets**, not code variants. The pipeline is
+constructed from the subset exactly as from a full deployment, so an ablated
+run exercises the same inference path a genuinely sparse deployment would.
+
+Marginal contribution of sensor `j`:
+
+```text
+Delta_j = performance(S) - performance(S \ {j})
+```
+
+evaluated on paired trajectories.
+
+Interaction between two sensors:
+
+```text
+interaction = joint_contribution - (individual_a + individual_b)
+```
+
+Positive means complementary, negative means redundant. Marginal sensor value
+is **not** assumed additive: a door tells you little without something to say
+who walked through it, so a sensor that looks worthless alone can be
+conditionally essential.
+
+## Reproducibility requirements
+
+Every experimental result records configuration, seed, sensor subset, metric
+definitions and the software version. Two runs of the same command produce
+byte-identical output; this is asserted by test, not merely intended.
+
+Generated datasets are not committed. Experiments regenerate from their seed.
+
+## Threats to validity
+
+Ordered by how much they should worry a reader.
+
+| Threat | Status |
+| --- | --- |
+| **All results come from one simulator, written by this project** | Unmitigated. The dominant limitation. |
+| Simulator encodes the project's beliefs about behaviour | Partially mitigated by structural independence and guard tests |
+| Seeds vary noise, not structure | Unmitigated. Intervals quantify Monte-Carlo variability under one model, not model uncertainty |
+| Occupancy and state layers share evidence | Unmitigated. Errors are correlated; uncertainty does not reflect it |
+| Pairing inflates standardised effect sizes | Mitigated by reporting raw differences alongside |
+| Metric choice could still flatter | Mitigated by reporting calibration and log loss alongside accuracy, where they disagree with it |
+| Cherry-picked sensor subsets | Mitigated: the CLI subsets are fixed, named, plausible deployments rather than a search |
+
+## What would make the evaluation trustworthy
+
+1. A public annotated smart-home dataset (CASAS, ARAS, MARBLE) scored with the
+   same metrics.
+2. Parameters fitted from data rather than declared.
+3. A second, independently written simulator with different structural
+   assumptions.
+4. Calibration assessed across households, not only within one.
+5. Prospective assessment of alert burden with people who would act on the
+   alerts, since false-positive tolerance is a human judgement no metric
+   supplies.

--- a/docs/MULTIMODAL_ARCHITECTURE.md
+++ b/docs/MULTIMODAL_ARCHITECTURE.md
@@ -1,0 +1,179 @@
+# Multimodal Ambient Sensing Architecture
+
+Design record for the multimodal layer built on top of the original modelling
+core. This document states what was audited, what the target architecture is,
+what the contracts between layers are, and what would count as each stage
+being finished.
+
+User-facing documentation lives in `ambient_architecture.rst`, `inference.rst`,
+`evaluation.rst` and `limitations.rst`. This file records the *decisions*.
+
+## 1. Audit of the pre-existing repository
+
+### What was already there and is reused
+
+| Component | Status | How it is used now |
+| --- | --- | --- |
+| `models/bernoulli_ar` | Working, tested | Unchanged. Still reachable via CLI and the analysis pipeline. |
+| `models/nhpp_pelt` | Working, tested | Unchanged. |
+| `models/change_point_detection/pelt.py` | Working, well validated | **Reused** by the adaptive baseline to locate step changes. |
+| `hmm/` | Working, lightweight | Retained. The fusion layer needed continuous-time dynamics and a per-modality likelihood, which `BaseHMM` does not provide, so it was not extended in place. |
+| `change_point/` | Working | Retained unchanged. |
+| `utils/missing.py` | Gap-aware masks and summaries | Retained. Complements, rather than duplicates, reliability tempering. |
+| `utils/data_io.SensorDataset` | Tabular container | Retained as the interop point for the tabular models. |
+| `analysis/` | Granger, dependency networks, metrics | Retained unchanged. |
+| `visualization/`, `cli.py` | Working | CLI extended with two subcommands; visualisation untouched. |
+| CI, packaging, release metadata | Working | Unchanged approach. |
+
+### Gaps that blocked multimodal fusion
+
+1. **No canonical observation.** Every model consumed a `DataFrame` on a
+   regular grid. There was nowhere to record modality, unit, device quality,
+   estimator confidence, or provenance, and no way to express that two
+   sensors report on different time bases.
+2. **No temporal semantics.** Nothing distinguished an event stream from a
+   sampled signal, so gap-filling could not be made safe by construction.
+3. **Sensor health was a detached utility.** `data/validation.detect_sensor_failures`
+   returned booleans that no model consumed, so a failed sensor could not be
+   discounted during inference.
+4. **No notion of who generated an activation.** Ambient events were
+   implicitly the resident's.
+5. **Fixed-step models only.** Asynchronous, irregular arrival could only be
+   handled by resampling, which fabricates data for event streams.
+6. **Ground truth and inference were not separated** in the simulator, so
+   evaluation risked being circular.
+
+### Technical debt noted but deliberately not addressed
+
+Fixing these was out of scope; addressing them would have mixed unrelated
+changes into scientific work.
+
+- 164 `mypy` errors across 31 older modules; CI gates `mypy` on two files.
+- `utils/data_io.simulate_sensor_data` and `analysis/pipeline` have high
+  cyclomatic complexity.
+- Several demo scripts under `examples/demos/` call APIs with wrong argument
+  names and would fail if run.
+- `pyproject.toml` declares heavyweight optional extras (`tensorflow`,
+  `torch`, `transformers`) that nothing in the repository uses.
+
+## 2. Target architecture
+
+```text
+heterogeneous observations
+        v
+observations/   canonical model, registry, boundary validation
+        v
+health/         per-sensor reliability as an evidence weight
+        v
+context/        occupancy and attribution
+        v
+states/ fusion/ latent behavioural state, P(Z_t | O_1:t)
+        v
+baseline/       adaptive personal normal, change verdicts
+        v
+alerts/         restrained, explained alerts
+        v
+interop/        provenance-preserving export
+
+online/         incremental orchestration of the above
+simulation/     synthetic households with ground truth
+evaluation/     metrics and paired ablation
+```
+
+### Why these boundaries
+
+- **`observations` is the only place hardware appears.** Everything above it
+  reads a `SensorRegistry`, never a sensor name. This is what makes ablation a
+  registry subset rather than a code change.
+- **`health` is separate from `observations`** so a malfunctioning sensor
+  never looks like a malformed message, and vice versa.
+- **`context` is separate from `fusion`** because "who is present" and "what
+  is the resident doing" are different questions with different state spaces.
+  Coupling them would have forced a joint state space that grows
+  multiplicatively.
+- **`states` holds the ontology, `fusion` holds the inference.** The ontology
+  is a deployment configuration; the filter is an algorithm.
+- **`online` performs no inference.** It owns buffering, day boundaries and
+  snapshotting only, so every scientific layer stays usable without it.
+- **`simulation` must not import from `fusion` or `states`.** Enforced by a
+  test.
+
+### Modules considered and rejected
+
+| Proposed | Decision |
+| --- | --- |
+| `modalities/` | Rejected. Modality is a field on an observation and a dispatch key in `fusion.defaults`; a package would have been an empty wrapper. |
+| `quality/` | Renamed to `health/`, which is what it actually estimates. |
+| `occupancy/` | Renamed to `context/`, since it produces attribution as well as occupancy. |
+| `preprocessing/` | Rejected. Modality-specific preprocessing belongs in the emission models, where the likelihood already encodes what the values mean. |
+
+## 3. Data contracts between layers
+
+Each contract is enforced at runtime, not merely documented.
+
+| Boundary | Contract |
+| --- | --- |
+| ingestion → everything | `Observation`: timezone-aware timestamp, registered `sensor_id`, declared modality, value finite and in the declared unit. Violations are rejected and counted, never raised into the stream. |
+| `health` → `fusion` | `dict[sensor_id, float]` in `[0, 1]`. Zero means *contributes nothing*, not *observed nothing*. |
+| `context` → `fusion` | `dict[sensor_id, float]` in `[0, 1]`: probability the resident generated what this sensor saw. Attributable sensors are always 1.0. |
+| `fusion` → `baseline` | `StateEstimate`: a normalised posterior over the ontology, plus completeness and per-sensor evidence. |
+| `baseline` → `alerts` | `BehaviouralChange`: a verdict with its kind, magnitude, duration, trend strength and the reference it was judged against. |
+| `alerts` → `interop` | `Alert`: severity, score, confidence and explicit caveats. |
+
+Two invariants hold everywhere and are tested:
+
+1. Every belief vector is finite, non-negative and sums to one.
+2. No layer may turn absence of evidence into evidence of absence.
+
+## 4. Backwards compatibility
+
+The multimodal layer is **purely additive**. No public symbol was removed or
+changed.
+
+- Existing model APIs, `SensorDataset`, the analysis pipeline and the
+  `bernoulli-ar` / `nhpp-pelt` CLI subcommands behave identically.
+- New CLI subcommands were added; none were altered.
+- `ObservationStream` provides `event_counts()`, `sample_frame()` and
+  `state_frame()` as the bridge from the canonical model into the tabular form
+  the older models expect.
+- `sensor_modeling.__all__` gained entries; it lost none.
+
+No migration is required. A user of the previous release can upgrade and
+ignore the new packages entirely.
+
+## 5. Staged plan and acceptance criteria
+
+| Stage | Delivered | Acceptance criterion | Status |
+| --- | --- | --- | --- |
+| 1 | Canonical observations, registry, ingestion, stream | Naive timestamps rejected; DST complete in both directions; event streams never forward-filled | Met |
+| 2 | Sensor health | A quiet event sensor is never called broken; a missing sensor yields reliability 0 | Met |
+| 3 | Ontology and fusion | Posterior normalised; reliability 0 contributes a flat likelihood; abstention available | Met |
+| 4 | Occupancy and attribution | Attribution falls when a visitor is present; attributable sensors stay at 1.0; no biometric evidence used | Met |
+| 5 | Adaptive baseline | Weekly rhythm not reported as change; poorly observed days excluded from history | Met |
+| 6 | Alerts | An unusual day is not an alert; bursts are capped; health alerts disclaim behavioural reading | Met |
+| 7 | Simulation | Generative process independent of the estimator, enforced by test | Met |
+| 8 | Evaluation and ablation | Paired design structural; unpaired series refused | Met |
+| 9 | Online pipeline | Bounded memory; snapshot/restore round-trips through JSON | Met |
+| 10 | Interoperability | Measurements and inferences distinguishable by provenance | Met |
+
+## 6. Architectural risks
+
+| Risk | Severity | Mitigation |
+| --- | --- | --- |
+| Occupancy and state layers share radar/beacon evidence, so their errors are correlated | **High** | Documented in `limitations.rst`. Not modelled. Would require a joint or hierarchical formulation. |
+| Emission parameters are declared, not fitted | **High** | Defaults derived from registry declarations and documented as starting points. Fitting is the top roadmap item after real-data validation. |
+| Simulator encodes the project's own beliefs about behaviour | **High** | Generative process deliberately differs from the estimator; two guard tests prevent convergence. Does not eliminate the risk. |
+| Presence samples are correlated but combined as independent | Medium | Explicit, inspectable `sample_weight` discount rather than an independence claim. |
+| Ontology is single-resident | Medium | Documented scope limit. Occupancy detects others but cannot track their states. |
+| No smoothing or backfill; late records beyond tolerance are dropped | Medium | Counted in `pipeline.too_late` rather than silently absorbed. |
+| Snapshots are unversioned | Low | Ontology mismatch is rejected with a clear error rather than misread. |
+
+## 7. Principles that constrained the design
+
+- Interpretable models before opaque ones. No neural component is on the
+  inference path, and none is planned.
+- No large language model anywhere in inference or alerting.
+- No cameras, microphones, or biometric identification. Attribution is
+  achieved from anonymous evidence and expressed as a probability.
+- Scientific algorithms are separable from I/O, storage and presentation.
+- A model that does not know must be able to say so.

--- a/docs/RESEARCH_QUESTIONS.md
+++ b/docs/RESEARCH_QUESTIONS.md
@@ -1,0 +1,141 @@
+# Research Questions
+
+What this platform is built to investigate, what would answer each question,
+and what would falsify the answer. Questions are stated so that a negative
+result is publishable and recognisable.
+
+## Central question
+
+> Can multimodal ambient sensing recover useful behavioural state using fewer
+> physical sensors, while explicitly representing uncertainty, sensor failure,
+> missingness, visitors, and person attribution?
+
+"Useful" is deliberately not "accurate". A system that is 90% accurate and
+badly calibrated is less useful for longitudinal monitoring than one that is
+80% accurate and knows when it is guessing, because the second can abstain and
+the first cannot.
+
+## RQ1 — Does modality substitute for count?
+
+**Question.** Does adding a small number of information-rich, person-bound
+sensors recover the behavioural information lost by removing several ambient
+sensors?
+
+**How it is answered.** `sensor-modeling ablate` evaluates named sensor
+subsets on identical simulated households and reports paired differences with
+bootstrap intervals.
+
+**What would answer it affirmatively.** A configuration with materially fewer
+sensors whose paired difference from the full deployment is small in
+*magnitude*, not merely statistically indistinguishable.
+
+**Current state.** Adding a wearable and beacon to six object sensors closes
+most of the gap: the remaining paired difference is 0.012 balanced accuracy
+(95% CI [+0.004, +0.020]). The gap is real but small.
+
+**What would falsify it.** A configuration that looks equivalent on balanced
+accuracy but is materially worse calibrated, or that degrades sharply under
+sensor failure. Both are measured, precisely because accuracy alone would hide
+them.
+
+**Known threat.** The result depends on the simulator's assumed activity
+levels and sensor rates. See `limitations.rst`.
+
+## RQ2 — Can a system fail safely rather than fail silently?
+
+**Question.** When sensors break, does behavioural inference degrade visibly
+and gracefully, or does it produce confident nonsense?
+
+**How it is answered.** Reliability sweeps at 5/10/20/40% missingness,
+injected dropouts, stuck sensors, wearable non-adherence, and total blackout,
+all scored with calibration alongside accuracy.
+
+**What would answer it affirmatively.** Accuracy declining smoothly while
+calibration error stays bounded, and abstention rising when evidence
+genuinely disappears.
+
+**Current state.** Balanced accuracy 0.858 → 0.748 across 0–40% loss with
+calibration error 0.046 → 0.079. Under total blackout the system abstains.
+
+**What would falsify it.** Any regime where confidence stays high while
+accuracy collapses. This is the failure mode the platform exists to prevent,
+and it is tested adversarially rather than assumed.
+
+## RQ3 — How much does person attribution matter?
+
+**Question.** How much does visitor and carer activity distort behavioural
+conclusions if ambient events are attributed to the resident by default?
+
+**How it is answered.** Synthetic households include a weekday carer and
+occasional visitors who trip the same ambient sensors. Naive attribution can
+be compared against occupancy-aware attribution on identical trajectories.
+
+**What would answer it affirmatively.** A measurable difference in state
+inference or in the behavioural-change verdicts between the two, in the
+direction of fewer spurious findings under occupancy-aware attribution.
+
+**What would falsify it.** Attribution making no measurable difference, which
+would mean either that contamination is negligible in this simulator or that
+the occupancy model is too weak to exploit it. Both are worth knowing, and
+visitor recall of roughly 0.48 means the second is a live possibility.
+
+## RQ4 — Can a personal baseline be adaptive without being amnesic?
+
+**Question.** Can a baseline track genuine long-run change in a person's
+routine while still detecting a decline, rather than absorbing the decline as
+the new normal?
+
+**How it is answered.** Injecting a known persistent change on a known day and
+measuring detection delay, alongside the unmatched alert burden per
+person-day during stable periods.
+
+**What would answer it affirmatively.** Detection within a clinically
+plausible window at an alert burden a carer would tolerate.
+
+**Current state.** Detection at six days, roughly 0.033 unmatched behavioural
+alerts per person-day.
+
+**What would falsify it.** A regime where lowering the threshold enough to
+detect real change floods the recipient. The threshold trades directly against
+delay, and that trade-off is a property of the method, not a tuning accident.
+
+## RQ5 — What is the cost of honesty?
+
+**Question.** What does a system give up by abstaining, by discounting
+unattributable evidence, and by refusing to fill gaps?
+
+**How it is answered.** Selective accuracy and abstention rate are reported
+alongside accuracy, so the accuracy sacrificed to abstention is visible.
+
+**Why it matters.** Every safety property in this platform has a cost in
+apparent performance. Reporting only the headline number would hide the price
+and make the conservative system look worse than a reckless one.
+
+## Explicit non-questions
+
+These are out of scope, and results here should not be read as bearing on
+them.
+
+- **Clinical effectiveness.** Nothing in this repository supports a claim that
+  monitoring improves any health outcome.
+- **Diagnosis.** No state maps to a clinical condition. `sleeping` is bed
+  occupancy with low movement, not polysomnographic sleep.
+- **Identity.** Attribution is a probability derived from anonymous evidence,
+  never a biometric identification.
+- **Multi-resident state tracking.** The ontology models one person; others
+  are detected but not tracked.
+- **Real-world performance.** Every quantitative result here comes from a
+  simulator written by this project.
+
+## What would make these answers trustworthy
+
+In priority order, and until the first is done, all answers above are
+conditional on the simulator:
+
+1. Evaluation on a public annotated smart-home dataset (CASAS, ARAS, MARBLE).
+2. Emission and dwell parameters fitted from data rather than declared.
+3. A second, independently written simulator with different structural
+   assumptions.
+4. Calibration assessed across households, not only within one.
+5. Prospective assessment of alert burden with people who would act on the
+   alerts.

--- a/docs/SENSOR_DATA_MODEL.md
+++ b/docs/SENSOR_DATA_MODEL.md
@@ -1,0 +1,193 @@
+# Sensor Data Model
+
+The contract every sensor record satisfies before any inference sees it, and
+the precise semantics of each field. Implemented in
+`sensor_modeling.observations`.
+
+## The canonical observation
+
+```python
+Observation(
+    timestamp,            # timezone-aware datetime, required
+    sensor_id,            # registered identifier
+    modality,             # what kind of physical evidence
+    kind,                 # EVENT | STATE | SAMPLE
+    value,                # finite float in `unit`
+    unit=Unit.NONE,
+    quality=1.0,          # device-reported measurement quality, [0, 1]
+    confidence=1.0,       # confidence the value is correct, [0, 1]
+    source="",            # gateway / hub / adapter identity
+    sampling_interval=None,
+    received_at=None,     # arrival time, for lateness and clock drift
+    flags=frozenset(),    # what ingestion repaired
+    context={},           # free-form string metadata
+)
+```
+
+Frozen and validated on construction. Rejected at the boundary: naive
+timestamps, non-finite values, empty sensor ids, probabilities outside
+`[0, 1]`, non-integer counts, non-positive sampling intervals.
+
+### quality versus confidence
+
+These are separate because they fail separately.
+
+- `quality` describes the **hardware**: a device reporting a low signal-to-noise
+  ratio, a weak battery, a marginal radio link.
+- `confidence` describes the **value**: an upstream estimator's own belief that
+  the number is right.
+
+A radar reporting a presence probability sets `confidence` below one even when
+the hardware is perfect. `evidence_weight()` multiplies them, because both must
+hold for the record to count as strong evidence.
+
+## Temporal semantics: the `kind` field
+
+This field exists to make one class of error impossible by construction.
+
+| Kind | Meaning | What a gap means | Permitted framing |
+| --- | --- | --- | --- |
+| `EVENT` | Instantaneous occurrence | **No event was recorded.** Not a zero. | Count per bin |
+| `STATE` | A level persisting until the next reported change | The level probably held | Carry forward, bounded by `max_hold` |
+| `SAMPLE` | Measurement of a continuously existing quantity | The quantity existed but was not measured | Mean per bin, `NaN` when absent |
+
+`ObservationStream` offers `event_counts()`, `state_frame()` and
+`sample_frame()` rather than one general `to_frame()`, so choosing the wrong
+framing requires calling the wrong method by name.
+
+`observed_mask()` is the companion to `event_counts()`: it separates *the
+sensor reported nothing* from *the sensor reported no activity*.
+
+## Modalities
+
+| Modality | Physical evidence | Default kind |
+| --- | --- | --- |
+| `CONTACT` | Open/close on an object (cupboard, fridge, drawer) | EVENT |
+| `DOOR` | Entrance or room door crossing | EVENT |
+| `MOTION` | PIR or equivalent binary movement | EVENT |
+| `VIBRATION` | Accelerometer-derived vibration on furniture | EVENT |
+| `ENVIRONMENTAL` | Ambient scalar (temperature, humidity, light, CO2) | SAMPLE |
+| `BED_PRESSURE` | Bed or chair occupancy from pressure or load cells | SAMPLE |
+| `WEARABLE_MOTION` | Accelerometer activity counts or magnitude | SAMPLE |
+| `WEARABLE_PHYSIOLOGY` | Heart rate, skin temperature | SAMPLE |
+| `ROOM_OCCUPANCY` | Room-level occupancy from an upstream device | SAMPLE |
+| `RADAR` | Derived mmWave feature. **Never raw radar cubes.** | SAMPLE |
+| `PROXIMITY` | Short-range presence beacon bound to an identity | SAMPLE |
+| `OTHER` | Anything else; adapters must document the semantics | SAMPLE |
+
+Defaults are conventions, overridable per sensor. They exist so the dangerous
+case — treating an event stream as a sampled signal — does not happen by
+omission.
+
+### Radar and mmWave
+
+The platform consumes **derived features**, not raw radar. Raw DSP is out of
+scope: it would couple the core to a specific chipset and add a large signal
+processing surface for no inferential gain the deployment cannot get from the
+device's own firmware.
+
+Supported derived features and their required semantics:
+
+| Feature | Unit | Meaning |
+| --- | --- | --- |
+| `presence_probability` | `PROBABILITY` | Device's belief that at least one person is in range |
+| `track_count` | `COUNT` | Number of simultaneously tracked people |
+| `range` | `METRE` | Distance to the nearest track |
+| `radial_velocity` | `METRE_PER_SECOND` | Signed velocity along the beam |
+| `motion_energy` | `NONE` | Device-defined movement magnitude; document its scale |
+| `posture_probability` | `PROBABILITY` | Device's belief in a named posture |
+| `fall_probability` | `PROBABILITY` | Device's belief a fall occurred |
+| `respiration_rate` | `BPM` | Estimated breaths per minute |
+
+Each must be registered as a separate `sensor_id` with its own `SensorSpec`.
+A device emitting several features is several sensors. Every one of these is a
+*derived feature*: `confidence` below one, and exported with derived
+provenance.
+
+## Units
+
+Units are explicit and converted at the boundary. Mismatched dimensions raise
+rather than passing through, because silently mixing Celsius and Fahrenheit
+corrupts every downstream statistic without any visible symptom.
+
+Supported: `NONE`, `PROBABILITY`, `COUNT`, `degC`, `degF`, `percent`, `lux`,
+`ppm`, `m`, `cm`, `m/s`, `cm/s`, `g`, `mg`, `bpm`, `s`, `min`.
+
+Affine conversion is handled for temperature; the rest are multiplicative.
+`PROBABILITY` is bounds-checked; `COUNT` is checked for non-negative
+integrality.
+
+## Declaring a deployment
+
+`SensorSpec` is how a deployment tells inference what a sensor is:
+
+```python
+SensorSpec(
+    sensor_id,
+    modality,
+    kind=None,               # defaults per modality
+    unit=Unit.NONE,
+    room=None,               # spatial claim, or None
+    expected_interval=None,  # a promise to report on a cadence
+    value_range=None,        # plausible bounds
+    prior_reliability=0.99,
+    attributable=False,      # does an activation identify *who*?
+    description="",          # documented semantics of the value
+)
+```
+
+Two fields carry more weight than their size suggests.
+
+**`expected_interval`** is a *promise*. Declaring it means prolonged silence
+is diagnostic of a fault. Leaving it `None` means silence is ambiguous between
+"broken" and "nobody used it", and the health monitor will decline to call a
+failure. Declaring it falsely makes a quiet cupboard look broken; omitting it
+falsely makes a dead sensor look quiet.
+
+**`attributable`** is true only for person-bound sensing — a worn device, a
+personal beacon. It is the difference between evidence about *this resident*
+and evidence about *the home*.
+
+## Temporal handling
+
+| Situation | Handling |
+| --- | --- |
+| Timezone-naive timestamp | Rejected. Never assumed UTC or local. |
+| Irregular sampling | Native. The continuous-time filter needs no grid. |
+| Duplicate delivery | Collapsed on `(utc_instant, sensor_id, value)`. |
+| Out-of-order arrival | Flagged, then reordered by the pipeline's lateness buffer. |
+| Late beyond tolerance | Counted in `pipeline.too_late`, not folded into an advanced belief. |
+| Clock drift | Estimated per source by minimum-latency filtering; corrections are flagged. |
+| Gaps | Reported by `stream.gaps()`. Interior only: silence before the first record cannot be distinguished from a sensor not yet installed. |
+| DST transitions | Framing bins on absolute UTC and labels in local time. Daily aggregation is bounded by local midnight, so a DST day is 23 or 25 hours. |
+
+Wall-clock arithmetic is confined to a single helper in the simulator.
+Everything else works in absolute time.
+
+## Sensor health vocabulary
+
+Estimated by `sensor_modeling.health`, consumed by fusion as an evidence
+weight.
+
+| Status | Weight | Meaning |
+| --- | --- | --- |
+| `HEALTHY` | 1.00 | Reporting as declared, plausible values |
+| `DEGRADED` | 0.60 | Reporting with reduced quality |
+| `DRIFTING` | 0.50 | Calibration shifted against its own history |
+| `UNKNOWN` | 0.50 | Not enough evidence to judge. The honest default. |
+| `OUT_OF_RANGE` | 0.20 | Implausible values persisting past tolerance |
+| `STUCK` | 0.10 | Unchanging where variation is expected |
+| `DROPOUT` | 0.05 | Silent long enough to suspect a fault |
+| `MISSING` | 0.00 | Supplies no evidence at all |
+
+`MISSING` is exactly zero by design. A sensor that is not reporting must
+contribute a flat likelihood, so the fusion layer falls back on other
+modalities rather than reading silence as inactivity.
+
+## Interop with the tabular models
+
+`ObservationStream` converts into the `DataFrame` form the original models
+expect, via `event_counts()`, `sample_frame()` and `state_frame()`. This is a
+deliberate one-way bridge: canonical observations can become tables, and the
+tabular models continue to work unchanged, but nothing above the observation
+layer consumes tables.

--- a/docs/UNCERTAINTY_MODEL.md
+++ b/docs/UNCERTAINTY_MODEL.md
@@ -1,0 +1,194 @@
+# Uncertainty Model
+
+How uncertainty is represented at each layer, how it propagates, where it is
+deliberately approximated, and what is not modelled at all.
+
+## The rule everything else follows from
+
+> A missing observation is missing evidence. It is never negative evidence
+> about the resident.
+
+Stated formally: for a sensor `s` with reliability `r_s = 0`, its contribution
+to the log-posterior is identically zero for every state. It does not favour
+low-activity states. It does not favour anything.
+
+This is enforced by the arithmetic rather than by a special case, which is
+why it cannot be forgotten in a future edit.
+
+## Layer by layer
+
+### 1. Observation
+
+Two independent scalars, both in `[0, 1]`:
+
+- `quality` — the device's report on its own hardware.
+- `confidence` — an upstream estimator's belief in the value.
+
+`evidence_weight() = quality x confidence`. Multiplicative because both must
+hold.
+
+Provenance flags record what ingestion repaired: `CLOCK_ADJUSTED`,
+`UNIT_CONVERTED`, `LATE_ARRIVAL`, `OUT_OF_ORDER`, `IMPUTED`. A downstream
+reader can always tell a measured timestamp from a corrected one.
+
+### 2. Sensor health
+
+Produces `reliability ∈ [0, 1]` per sensor:
+
+```text
+reliability = prior_reliability x smoothed_quality x status_weight
+```
+
+The status weight is a fixed, documented table (see `SENSOR_DATA_MODEL.md`).
+`MISSING` is zero; `UNKNOWN` is 0.5, because absence of a verdict is not a
+verdict of failure.
+
+### 3. Occupancy context
+
+A posterior over four contexts, maintained by a continuous-time chain.
+Marginalised into scalars:
+
+```text
+P(resident_home)         = P(alone) + P(with_visitor)
+P(visitor_present)       = P(with_visitor) + P(visitor_only)
+P(multiple_people)       = P(with_visitor)
+attribution              = sum_c P(c) x resident_share(c)
+```
+
+`resident_share` is a declared per-context constant: 1.0 when alone, 0.5 in a
+shared household, 0.0 when the resident is out. The 0.5 encodes genuine
+ignorance about who did what, which is the honest value when two people are
+present and nothing distinguishes them.
+
+### 4. Fusion
+
+The core quantity is `P(Z_t | O_1:t)`, maintained by forward filtering.
+
+**Prediction.** `b <- b · exp(Q·Δt)`, where `Q` is the ontology generator.
+Uncertainty grows with elapsed time automatically: with no evidence the belief
+relaxes toward the stationary distribution, so confidence decays rather than
+persisting.
+
+**Update.** Each sensor contributes a tempered, centred log-likelihood:
+
+```text
+loglik_s = w_s · r_s · a_s · (raw_s − max(raw_s))
+```
+
+- `w_s` — modality evidence weight, correcting for sampling-rate imbalance.
+- `r_s` — reliability from health.
+- `a_s` — attribution from context.
+
+**Why tempering rather than gating.** Multiplying the log-likelihood by a
+weight in `[0, 1]` is a power-likelihood update in the sense of generalised
+Bayesian updating. It degrades smoothly, it has a defined meaning at every
+intermediate value, and at zero it is exactly a flat likelihood. A hard gate
+would be discontinuous and would need a threshold nobody can justify.
+
+**Why centring.** State-independent constants cancel under normalisation, so
+subtracting the maximum changes nothing about the posterior. It makes each
+model's output directly readable as "how much worse is this state than the
+best one, according to this sensor", which is what the explanation layer
+reports.
+
+### 5. What each estimate exposes
+
+`StateEstimate` never reports only an argmax:
+
+| Quantity | Meaning |
+| --- | --- |
+| `probabilities` | The full posterior |
+| `confidence` | Mass on the leading state |
+| `margin` | Gap between the top two |
+| `normalised_entropy` | 1.0 means completely undecided |
+| `completeness` | Mean sensor reliability behind the estimate |
+| `supporting` / `contradicting` | Per-sensor log-likelihood margin for the reported state |
+| `silent` | Trusted sensors that reported nothing |
+| `missing` | Sensors discounted to zero reliability |
+
+The `silent` / `missing` distinction matters. A working-but-quiet event sensor
+is *informative*: under a Poisson model its silence actively penalises the
+states that would have triggered it. A dead sensor is not. Collapsing the two
+would be the same error as filling event gaps with zeros.
+
+### 6. Abstention
+
+```text
+state = UNKNOWN if confidence < min_confidence
+                 or completeness < min_completeness
+```
+
+Two independent reasons, because they are different failures. A flat posterior
+means the evidence is ambiguous; low completeness means there was barely any
+evidence to be ambiguous about.
+
+`UNKNOWN` is excluded from the ontology's state vector by construction. It is
+an abstention, not an eighth behaviour, and `StateOntology` rejects any attempt
+to include it.
+
+### 7. Baseline
+
+Daily features are accumulated from the posterior:
+
+```text
+hours(state) = sum_t P(state | t) · Δt
+```
+
+not by counting argmax wins. A day of 60%-confident guesses and a day of
+99%-confident conclusions are genuinely different, and collapsing to argmax
+first would erase that difference before the baseline saw it.
+
+Deviation is a **robust** z-score against a median/MAD reference, weekday-aware
+where enough same-weekday history exists. `min_scale` floors the denominator
+so an extremely regular person does not have every ordinary hour of variation
+reported as an enormous deviation.
+
+Poorly observed days are excluded from the history entirely, not entered as
+low values.
+
+### 8. Alerts
+
+Confidence is `coverage x attribution`. Below `min_confidence` nothing is
+raised regardless of magnitude: a large change seen through a broken
+deployment, or during a visit, is not actionable.
+
+Above it, uncertainty is preserved as explicit **caveats** on the alert rather
+than folded into the score, so the recipient sees the reservation rather than
+a number that silently absorbed it.
+
+## Deliberate approximations
+
+Each of these is a known departure from exactness, chosen for interpretability
+or tractability, and recorded rather than hidden.
+
+| Approximation | Where | Consequence |
+| --- | --- | --- |
+| Sensors are conditionally independent given the state | Fusion | Log-likelihoods add. Correlated sensors are over-counted. Partially compensated by per-modality `weight`. |
+| Presence samples treated as independent, then discounted | Context | `sample_weight` is chosen, not estimated. Without it the posterior reaches certainty within minutes. |
+| Fast wearable sampling discounted by a fixed weight | Fusion defaults | `weight=0.25` is a judgement, not a fit. |
+| Filtering, not smoothing | Baseline | Each estimate is attributed to the interval preceding it, which lags slightly at transitions. |
+| Markov dynamics | Ontology | State duration is implicitly exponential. Real dwell times are not. |
+| Bootstrap intervals across seeds | Evaluation | Quantify Monte-Carlo variability under one model, not uncertainty about the model. |
+
+## Not modelled
+
+- **Correlation between the occupancy and state layers.** They share radar and
+  beacon evidence, so their errors are dependent, and the reported uncertainty
+  does not reflect that. This is the largest known gap.
+- **Parameter uncertainty.** Dwell times, rates and priors are point values.
+  There is no posterior over them.
+- **Calibration correction.** Calibration is measured and reported; no
+  temperature scaling or isotonic correction is applied.
+- **Uncertainty in the ontology itself.** The state set is assumed correct.
+
+## How to check these claims
+
+The properties above are tested rather than asserted:
+
+- `tests/test_fusion.py` — reliability zero contributes nothing; partial
+  reliability scales linearly; posteriors normalise; abstention triggers.
+- `tests/test_adversarial.py` — total blackout abstains; higher missingness is
+  never rewarded; every belief remains a valid distribution under combined
+  loss, duplication, lateness and drift.
+- `tests/test_evaluation.py` — calibration error rises with overconfidence;
+  log loss punishes confident errors more than hedged ones.


### PR DESCRIPTION
Five design documents recording the audit, target architecture, data contracts, uncertainty model and evaluation design. Restructures ROADMAP by theme.

Documentation only; no code changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds five design records documenting the multimodal platform's target architecture, data contracts, uncertainty model, research questions, and evaluation design. Restructures `ROADMAP.md` to group work by capability theme instead of delivery phases.

<sup>Written for commit 1db9259bebd3b96fe24cb6de959015c104bd6c1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/61?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

