### PR TITLE
Add legacy adapters and property-based tests for observations

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ The Sensor Modeling Research Toolkit provides utilities for analyzing, modeling,
    clinical_examples
    architecture
    ambient_architecture
+   multimodal_ingestion
    inference
    evaluation
    limitations

--- a/docs/multimodal_ingestion.rst
+++ b/docs/multimodal_ingestion.rst
@@ -1,0 +1,184 @@
+Ingesting Heterogeneous Sensors
+===============================
+
+How four physically unlike sensors reach the same inference pipeline without
+any hardware-specific logic leaking downstream.
+
+The principle
+-------------
+
+Every adapter produces
+:class:`~sensor_modeling.observations.Observation`. Every stage above the
+observation layer reads a
+:class:`~sensor_modeling.observations.SensorRegistry`, never a sensor name.
+Adding a device to a deployment therefore means adding a declaration, not
+editing inference code.
+
+Declaring the deployment
+------------------------
+
+.. code-block:: python
+
+    from datetime import timedelta
+
+    from sensor_modeling.observations import (
+        Modality, ObservationKind, SensorRegistry, SensorSpec, Unit,
+    )
+
+    registry = SensorRegistry.from_specs([
+        # An event sensor. It makes no promise to report, so its silence is
+        # never treated as a fault.
+        SensorSpec(
+            "front_door", Modality.DOOR, room="hall",
+            description="Contact on the entrance door; fires on any crossing.",
+        ),
+
+        # A state sensor: a level that persists until it changes.
+        SensorSpec(
+            "bed_pressure", Modality.BED_PRESSURE,
+            kind=ObservationKind.STATE, room="bedroom",
+            expected_interval=timedelta(minutes=5),
+            value_range=(0.0, 1.0),
+            description="Load cell reporting bed occupancy as a level.",
+        ),
+
+        # A person-bound sampled sensor. `attributable` is what distinguishes
+        # evidence about *this resident* from evidence about the home.
+        SensorSpec(
+            "wearable_motion", Modality.WEARABLE_MOTION,
+            kind=ObservationKind.SAMPLE,
+            expected_interval=timedelta(minutes=1),
+            value_range=(0.0, 10.0), attributable=True,
+            description="Accelerometer activity magnitude from a worn device.",
+        ),
+
+        # A derived mmWave feature. Not raw radar, and not a measurement:
+        # observations from it carry a confidence below one.
+        SensorSpec(
+            "living_radar", Modality.RADAR,
+            kind=ObservationKind.SAMPLE, unit=Unit.COUNT,
+            room="living", expected_interval=timedelta(minutes=1),
+            value_range=(0.0, 6.0),
+            description="Derived mmWave feature: number of tracked people.",
+        ),
+    ])
+
+Four adapters, one observation type
+-----------------------------------
+
+.. code-block:: python
+
+    from datetime import datetime, timezone
+    from sensor_modeling.observations import Observation
+
+    now = datetime(2024, 5, 1, 8, 0, tzinfo=timezone.utc)
+
+    door = Observation(
+        timestamp=now, sensor_id="front_door",
+        modality=Modality.DOOR, kind=ObservationKind.EVENT, value=1.0,
+    )
+
+    bed = Observation(
+        timestamp=now, sensor_id="bed_pressure",
+        modality=Modality.BED_PRESSURE, kind=ObservationKind.STATE, value=1.0,
+    )
+
+    wearable = Observation(
+        timestamp=now, sensor_id="wearable_motion",
+        modality=Modality.WEARABLE_MOTION, kind=ObservationKind.SAMPLE,
+        value=0.04,
+    )
+
+    # A derived feature states its own uncertainty. The device computed this
+    # number; it did not measure it.
+    radar = Observation(
+        timestamp=now, sensor_id="living_radar",
+        modality=Modality.RADAR, kind=ObservationKind.SAMPLE,
+        value=2.0, unit=Unit.COUNT, confidence=0.75,
+    )
+
+Running the pipeline
+--------------------
+
+The pipeline is constructed from the registry alone. It contains no branch on
+sensor identity, and derives its observation models from the declarations.
+
+.. code-block:: python
+
+    from sensor_modeling.online import BehaviouralSensingPipeline, PipelineConfig
+
+    pipeline = BehaviouralSensingPipeline(
+        registry, config=PipelineConfig(step=timedelta(minutes=5))
+    )
+
+    for observation in (door, bed, wearable, radar):
+        pipeline.push(observation)
+
+    for step in pipeline.advance(now + timedelta(minutes=20)):
+        print(step.state.explain())
+
+Swapping a modality out is a registry change:
+
+.. code-block:: python
+
+    without_radar = registry.subset(
+        ["front_door", "bed_pressure", "wearable_motion"]
+    )
+    sparse = BehaviouralSensingPipeline(without_radar)
+
+This is the same mechanism the ablation framework uses, which is why an
+ablated run exercises the same inference path a genuinely sparse deployment
+would.
+
+Converting legacy tabular data
+------------------------------
+
+The original toolkit represents sensor data as a timestamp-indexed frame with
+one column per sensor. :mod:`sensor_modeling.observations.adapters` converts
+it, but requires a registry, because the frame carries no modality, no unit
+and no temporal semantics.
+
+.. code-block:: python
+
+    from sensor_modeling.observations import observations_from_frame
+
+    observations = list(observations_from_frame(legacy_frame, registry))
+
+Two behaviours are worth knowing about.
+
+**Zeros in event columns are dropped.** A zero in a motion column is the
+absence of a record, not an observation that nothing happened. Emitting it
+would fabricate exactly the evidence the canonical model exists to withhold.
+Zeros in state and sample columns are kept, because there a zero is a genuine
+measurement.
+
+**A naive index is refused.** Assuming UTC or local time would silently shift
+every record by hours and break daily-rhythm analysis across DST boundaries,
+so the timezone must be supplied:
+
+.. code-block:: python
+
+    observations_from_frame(legacy_frame, registry, tz=ZoneInfo("Europe/Lisbon"))
+
+Long-format records -- one row per reading -- are also supported through
+:func:`~sensor_modeling.observations.observations_from_records`, and carry
+event semantics correctly by construction, since an absent row is simply an
+absent row.
+
+Going back to tables
+--------------------
+
+Conversion runs one way for inference, but
+:class:`~sensor_modeling.observations.ObservationStream` frames observations
+back into tables so the original models keep working:
+
+.. code-block:: python
+
+    stream.event_counts("15min")    # activations per bin; zeros mean "not recorded"
+    stream.observed_mask("15min")   # did anything arrive at all?
+    stream.sample_frame("15min")    # mean per bin; NaN where unsampled
+    stream.state_frame("15min", max_hold=timedelta(hours=2))
+
+There are three methods rather than one general ``to_frame()`` so that
+choosing the wrong framing for a modality requires calling the wrong method by
+name.

--- a/sensor_modeling/observations/__init__.py
+++ b/sensor_modeling/observations/__init__.py
@@ -7,6 +7,13 @@ measured in, the reliability attached to it, and the provenance of any repair
 applied during ingestion, so that later stages can weight it honestly.
 """
 
+from .adapters import (
+    LegacyConversionError,
+    naive_utc,
+    observations_from_dataset,
+    observations_from_frame,
+    observations_from_records,
+)
 from .ingest import (
     ClockOffsetEstimator,
     IngestionReport,
@@ -28,6 +35,7 @@ __all__ = [
     "ClockOffsetEstimator",
     "Gap",
     "IngestionReport",
+    "LegacyConversionError",
     "Modality",
     "Observation",
     "ObservationFlag",
@@ -42,6 +50,10 @@ __all__ = [
     "UnknownSensorError",
     "convert",
     "default_kind",
+    "naive_utc",
+    "observations_from_dataset",
+    "observations_from_frame",
+    "observations_from_records",
     "require_aware",
     "to_canonical",
 ]

--- a/sensor_modeling/observations/adapters.py
+++ b/sensor_modeling/observations/adapters.py
@@ -1,0 +1,195 @@
+"""Converting legacy tabular sensor data into canonical observations.
+
+The original toolkit represents sensor data as a :class:`~pandas.DataFrame`
+indexed by timestamp with one column per sensor. That form carries no
+modality, no unit, no quality, and -- most consequentially -- no distinction
+between an event stream and a sampled signal.
+
+These adapters bridge the two, but they cannot invent the missing information.
+A caller must supply a :class:`~sensor_modeling.observations.SensorRegistry`
+saying what each column actually is. That requirement is deliberate: guessing
+a column's modality from its name is exactly the hardware-specific coupling
+the canonical model exists to remove, and guessing its *kind* would decide,
+invisibly, whether a gap in the data means "nothing happened" or "nothing was
+measured".
+
+Conversion runs in one direction only. Canonical observations can be framed
+back into tables through :class:`~sensor_modeling.observations.ObservationStream`,
+so the older models keep working unchanged, but nothing above the observation
+layer consumes tables.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator, Mapping
+from datetime import datetime, timezone, tzinfo
+
+import pandas as pd
+
+from .observation import Observation
+from .registry import SensorRegistry, UnknownSensorError
+from .types import ObservationKind
+
+logger = logging.getLogger(__name__)
+
+
+class LegacyConversionError(ValueError):
+    """Raised when a legacy frame cannot be converted without guessing."""
+
+
+def _localise(index: pd.DatetimeIndex, tz: tzinfo | None) -> pd.DatetimeIndex:
+    """Return *index* as timezone-aware, without inventing an offset.
+
+    A naive legacy frame carries no timezone, so one must be supplied. It is
+    never assumed, because assuming UTC or local silently shifts every record
+    by hours and breaks daily-rhythm analysis across DST boundaries.
+    """
+    if index.tz is not None:
+        return index
+    if tz is None:
+        raise LegacyConversionError(
+            "legacy frame has naive timestamps; pass tz= to say which timezone "
+            "they were recorded in rather than having one assumed"
+        )
+    return index.tz_localize(tz)
+
+
+def observations_from_frame(
+    frame: pd.DataFrame,
+    registry: SensorRegistry,
+    *,
+    tz: tzinfo | None = None,
+    source: str = "legacy-frame",
+    skip_unregistered: bool = False,
+) -> Iterator[Observation]:
+    """Yield canonical observations from a legacy sensor frame.
+
+    Parameters
+    ----------
+    frame
+        Timestamp-indexed frame with one column per sensor.
+    registry
+        Declarations for the columns. Every column must be registered, so that
+        modality, unit and temporal semantics come from the deployment rather
+        than from a guess.
+    tz
+        Timezone of a naive index. Required when the index is naive.
+    source
+        Value recorded as the observation's ``source``.
+    skip_unregistered
+        When true, unregistered columns are logged and skipped instead of
+        raising. Useful for frames carrying derived columns alongside sensors.
+
+    Yields
+    ------
+    Observation
+        One record per non-null cell, in timestamp order.
+
+    Notes
+    -----
+    Zero-valued cells are emitted for ``STATE`` and ``SAMPLE`` sensors, whose
+    zeros are genuine measurements, but **not** for ``EVENT`` sensors, whose
+    zeros are the absence of a record rather than an observation of nothing.
+    Emitting them would fabricate exactly the evidence the canonical model
+    exists to withhold.
+    """
+    if not isinstance(frame.index, pd.DatetimeIndex):
+        raise LegacyConversionError("legacy frame must be indexed by timestamp")
+
+    index = _localise(frame.index, tz)
+    columns = []
+    for column in frame.columns:
+        spec = registry.get(str(column))
+        if spec is None:
+            if skip_unregistered:
+                logger.debug("Skipping unregistered column '%s'", column)
+                continue
+            raise UnknownSensorError(
+                f"column '{column}' is not registered; declare it in the "
+                "registry so its modality and temporal semantics are explicit"
+            )
+        columns.append((str(column), spec))
+
+    if not columns:
+        return
+
+    for position, moment in enumerate(index):
+        timestamp = moment.to_pydatetime()
+        for name, spec in columns:
+            value = frame.iloc[position][name]
+            if pd.isna(value):
+                continue
+            numeric = float(value)
+            if spec.kind is ObservationKind.EVENT and numeric == 0.0:
+                continue
+            yield Observation(
+                timestamp=timestamp,
+                sensor_id=name,
+                modality=spec.modality,
+                kind=spec.kind or ObservationKind.SAMPLE,
+                value=numeric,
+                unit=spec.unit,
+                source=source,
+                context={"origin": "legacy-frame"},
+            )
+
+
+def observations_from_dataset(
+    dataset: object,
+    registry: SensorRegistry,
+    **kwargs: object,
+) -> Iterator[Observation]:
+    """Yield canonical observations from a legacy ``SensorDataset``.
+
+    Accepts anything exposing ``to_dataframe()``, which keeps this adapter
+    from importing the older data layer and creating a cycle.
+    """
+    to_dataframe = getattr(dataset, "to_dataframe", None)
+    if to_dataframe is None:
+        raise LegacyConversionError("dataset must expose to_dataframe()")
+    return observations_from_frame(to_dataframe(), registry, **kwargs)  # type: ignore[arg-type]
+
+
+def observations_from_records(
+    records: object,
+    registry: SensorRegistry,
+    *,
+    timestamp_key: str = "timestamp",
+    sensor_key: str = "sensor_id",
+    value_key: str = "value",
+    source: str = "legacy-records",
+) -> Iterator[Observation]:
+    """Yield canonical observations from long-format records.
+
+    Long format -- one row per reading, with a sensor column -- is what most
+    event-driven gateways export, and it carries event semantics correctly
+    because an absent row is simply an absent row.
+    """
+    for record in records:  # type: ignore[attr-defined]
+        if not isinstance(record, Mapping):
+            raise LegacyConversionError("each record must be a mapping")
+        sensor_id = str(record[sensor_key])
+        spec = registry[sensor_id]
+        yield Observation(
+            timestamp=record[timestamp_key],
+            sensor_id=sensor_id,
+            modality=spec.modality,
+            kind=spec.kind or ObservationKind.SAMPLE,
+            value=float(record[value_key]),
+            unit=spec.unit,
+            source=str(record.get("source", source)),
+            context={"origin": "legacy-records"},
+        )
+
+
+def naive_utc(moment: datetime) -> datetime:
+    """Attach UTC to a naive datetime, explicitly and visibly.
+
+    Provided so that a caller who genuinely knows their legacy data is UTC can
+    say so at the call site, rather than having the assumption buried in a
+    conversion routine.
+    """
+    if moment.tzinfo is not None:
+        return moment
+    return moment.replace(tzinfo=timezone.utc)

--- a/tests/property/test_observation_properties.py
+++ b/tests/property/test_observation_properties.py
@@ -1,0 +1,185 @@
+"""Property-based tests for the canonical observation model.
+
+These assert invariants that must hold for *every* valid observation and
+stream, rather than for the handful of cases an example-based test happens to
+pick. They are the tests most likely to find an edge case nobody thought of.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from hypothesis import HealthCheck, assume, given, settings
+from hypothesis import strategies as st
+
+from sensor_modeling.observations import (
+    Modality,
+    Observation,
+    ObservationKind,
+    ObservationStream,
+    Unit,
+    convert,
+    to_canonical,
+)
+
+EPOCH = datetime(2024, 5, 1, tzinfo=timezone.utc)
+
+# Offsets rather than datetimes, and a small sensor vocabulary: the invariants
+# under test do not depend on the richness of either, and cheap strategies keep
+# the suite fast enough to run on every commit.
+OFFSETS = st.integers(min_value=0, max_value=60 * 24 * 30)
+SENSOR_IDS = st.sampled_from(["a", "b", "c", "kitchen_motion", "bed"])
+UNIT_INTERVAL = st.floats(min_value=0.0, max_value=1.0, allow_nan=False)
+VALUES = st.floats(min_value=-1e6, max_value=1e6, allow_nan=False, allow_infinity=False)
+
+# The strategies below are deliberately cheap -- sampled_from, integers and
+# bounded floats. Hypothesis nonetheless attributes one-off warm-up cost to
+# whichever example is drawn first, which trips the too_slow health check at
+# random depending on test order. Suppressing it here is a statement about
+# that measurement artefact, not a licence for an expensive strategy.
+FAST = settings(max_examples=50, suppress_health_check=[HealthCheck.too_slow])
+
+
+@st.composite
+def observations(draw: st.DrawFn) -> Observation:
+    """Generate an arbitrary valid observation."""
+    return Observation(
+        timestamp=EPOCH + timedelta(minutes=draw(OFFSETS)),
+        sensor_id=draw(SENSOR_IDS),
+        modality=draw(st.sampled_from(list(Modality))),
+        kind=draw(st.sampled_from(list(ObservationKind))),
+        value=draw(VALUES),
+        quality=draw(UNIT_INTERVAL),
+        confidence=draw(UNIT_INTERVAL),
+    )
+
+
+@given(observations())
+@FAST
+def test_every_observation_round_trips_through_its_dict(obs: Observation) -> None:
+    """Serialisation must be lossless, or a snapshot silently corrupts state."""
+    assert Observation.from_dict(obs.to_dict()) == obs
+
+
+@given(observations())
+@FAST
+def test_evidence_weight_stays_in_the_unit_interval(obs: Observation) -> None:
+    assert 0.0 <= obs.evidence_weight() <= 1.0
+
+
+@given(observations())
+@FAST
+def test_every_observation_is_hashable(obs: Observation) -> None:
+    assert isinstance(hash(obs), int)
+
+
+@given(observations())
+@FAST
+def test_timestamps_are_always_timezone_aware(obs: Observation) -> None:
+    assert obs.timestamp.tzinfo is not None
+    assert obs.timestamp.tzinfo.utcoffset(obs.timestamp) is not None
+
+
+@given(
+    st.floats(min_value=-200.0, max_value=200.0, allow_nan=False),
+    st.sampled_from([Unit.CELSIUS, Unit.FAHRENHEIT]),
+)
+def test_temperature_conversion_is_reversible(value: float, unit: Unit) -> None:
+    other = Unit.FAHRENHEIT if unit is Unit.CELSIUS else Unit.CELSIUS
+    assert abs(convert(convert(value, unit, other), other, unit) - value) < 1e-6
+
+
+@given(
+    st.floats(min_value=0.0, max_value=1e5, allow_nan=False),
+    st.sampled_from(
+        [Unit.CENTIMETRE, Unit.CENTIMETRE_PER_SECOND, Unit.MILLI_G, Unit.MINUTE]
+    ),
+)
+def test_canonicalisation_preserves_magnitude_order(value: float, unit: Unit) -> None:
+    """Converting to canonical units must not reorder two readings."""
+    smaller, _ = to_canonical(value, unit)
+    larger, _ = to_canonical(value + 1.0, unit)
+    assert smaller <= larger
+
+
+@given(st.lists(observations(), min_size=1, max_size=40))
+@FAST
+def test_a_stream_is_always_sorted_regardless_of_arrival_order(
+    records: list[Observation],
+) -> None:
+    stream = ObservationStream.from_observations(records)
+    stamps = [obs.timestamp.astimezone(timezone.utc) for obs in stream]
+    assert stamps == sorted(stamps)
+
+
+@given(st.lists(observations(), min_size=1, max_size=40))
+@FAST
+def test_a_stream_never_holds_duplicate_identities(
+    records: list[Observation],
+) -> None:
+    stream = ObservationStream.from_observations(records)
+    identities = [obs.identity() for obs in stream]
+    assert len(identities) == len(set(identities))
+
+
+@given(st.lists(observations(), min_size=1, max_size=30))
+@FAST
+def test_re_adding_every_record_changes_nothing(
+    records: list[Observation],
+) -> None:
+    """Replaying a batch must be idempotent, since gateways redeliver."""
+    stream = ObservationStream.from_observations(records)
+    before = len(stream)
+    stream.extend(records)
+    assert len(stream) == before
+
+
+@given(st.lists(observations(), min_size=2, max_size=30))
+@FAST
+def test_event_counts_never_exceed_the_events_supplied(
+    records: list[Observation],
+) -> None:
+    """Framing may drop nothing into existence."""
+    events = [
+        obs
+        for obs in ObservationStream.from_observations(records)
+        if obs.kind is ObservationKind.EVENT and obs.value != 0.0
+    ]
+    assume(events)
+    stream = ObservationStream.from_observations(records)
+    counts = stream.event_counts("1h")
+    assert counts.values.sum() <= len(events)
+
+
+@given(st.lists(observations(), min_size=1, max_size=30))
+@FAST
+def test_the_observed_mask_is_never_true_where_nothing_arrived(
+    records: list[Observation],
+) -> None:
+    stream = ObservationStream.from_observations(records)
+    mask = stream.observed_mask("1h")
+    assert mask.values.sum() <= len(stream)
+
+
+@given(
+    st.integers(min_value=1, max_value=48),
+    st.integers(min_value=1, max_value=6),
+)
+def test_gaps_are_reported_only_between_recorded_observations(
+    spacing_minutes: int, count: int
+) -> None:
+    start = datetime(2024, 5, 1, tzinfo=timezone.utc)
+    records = [
+        Observation(
+            timestamp=start + timedelta(minutes=spacing_minutes * index),
+            sensor_id="s",
+            modality=Modality.MOTION,
+            kind=ObservationKind.EVENT,
+            value=1.0,
+        )
+        for index in range(count)
+    ]
+    stream = ObservationStream.from_observations(records)
+    gaps = stream.gaps("s", timedelta(minutes=1))
+    assert all(stream.start <= gap.start and gap.end <= stream.end for gap in gaps)
+    assert len(gaps) <= max(count - 1, 0)

--- a/tests/test_observation_adapters.py
+++ b/tests/test_observation_adapters.py
@@ -1,0 +1,191 @@
+"""Tests for converting legacy tabular data into canonical observations."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+import pytest
+
+from sensor_modeling.observations import (
+    LegacyConversionError,
+    Modality,
+    ObservationKind,
+    SensorRegistry,
+    SensorSpec,
+    Unit,
+    UnknownSensorError,
+    naive_utc,
+    observations_from_dataset,
+    observations_from_frame,
+    observations_from_records,
+)
+from sensor_modeling.utils.data_io import SensorDataset
+
+LISBON = ZoneInfo("Europe/Lisbon")
+T0 = datetime(2024, 5, 1, 8, 0, tzinfo=timezone.utc)
+
+
+def registry() -> SensorRegistry:
+    """A registry covering an event, a state and a sampled sensor."""
+    return SensorRegistry.from_specs(
+        [
+            SensorSpec("kitchen_motion", Modality.MOTION, room="kitchen"),
+            SensorSpec(
+                "bed",
+                Modality.BED_PRESSURE,
+                kind=ObservationKind.STATE,
+                room="bedroom",
+            ),
+            SensorSpec(
+                "hall_temp",
+                Modality.ENVIRONMENTAL,
+                kind=ObservationKind.SAMPLE,
+                unit=Unit.CELSIUS,
+                room="hall",
+            ),
+        ]
+    )
+
+
+def frame(*, tz: object = timezone.utc) -> pd.DataFrame:
+    """A legacy wide frame with one column per sensor."""
+    naive_start = T0.replace(tzinfo=None)
+    index = pd.date_range(naive_start, periods=4, freq="15min", tz=tz)
+    return pd.DataFrame(
+        {
+            "kitchen_motion": [1.0, 0.0, 1.0, 0.0],
+            "bed": [0.0, 0.0, 1.0, 1.0],
+            "hall_temp": [20.0, 20.5, 21.0, 20.8],
+        },
+        index=index,
+    )
+
+
+class TestWideFrameConversion:
+    def test_every_registered_column_is_converted(self) -> None:
+        observations = list(observations_from_frame(frame(), registry()))
+        by_sensor = {obs.sensor_id for obs in observations}
+        assert by_sensor == {"kitchen_motion", "bed", "hall_temp"}
+
+    def test_event_zeros_are_not_emitted_as_observations(self) -> None:
+        """A zero in an event column is an absent record, not an observation.
+
+        Emitting it would fabricate the exact evidence the canonical model
+        exists to withhold.
+        """
+        observations = list(observations_from_frame(frame(), registry()))
+        motion = [o for o in observations if o.sensor_id == "kitchen_motion"]
+        assert len(motion) == 2
+        assert all(obs.value == 1.0 for obs in motion)
+
+    def test_state_and_sample_zeros_are_kept(self) -> None:
+        """A bed reading zero is a genuine measurement of an empty bed."""
+        observations = list(observations_from_frame(frame(), registry()))
+        bed = [o for o in observations if o.sensor_id == "bed"]
+        assert len(bed) == 4
+        assert bed[0].value == 0.0
+
+    def test_declared_semantics_are_applied(self) -> None:
+        observations = list(observations_from_frame(frame(), registry()))
+        temp = next(o for o in observations if o.sensor_id == "hall_temp")
+        assert temp.modality is Modality.ENVIRONMENTAL
+        assert temp.kind is ObservationKind.SAMPLE
+        assert temp.unit is Unit.CELSIUS
+
+    def test_missing_cells_are_skipped_not_imputed(self) -> None:
+        data = frame()
+        data.loc[data.index[1], "hall_temp"] = None
+        observations = list(observations_from_frame(data, registry()))
+        assert len([o for o in observations if o.sensor_id == "hall_temp"]) == 3
+
+    def test_an_unregistered_column_is_refused_rather_than_guessed(self) -> None:
+        data = frame()
+        data["mystery"] = 1.0
+        with pytest.raises(UnknownSensorError, match="not registered"):
+            list(observations_from_frame(data, registry()))
+
+    def test_unregistered_columns_can_be_skipped_explicitly(self) -> None:
+        data = frame()
+        data["derived_feature"] = 1.0
+        observations = list(
+            observations_from_frame(data, registry(), skip_unregistered=True)
+        )
+        assert "derived_feature" not in {o.sensor_id for o in observations}
+
+    def test_a_naive_index_requires_an_explicit_timezone(self) -> None:
+        """Assuming UTC or local would silently shift every record."""
+        with pytest.raises(LegacyConversionError, match="naive timestamps"):
+            list(observations_from_frame(frame(tz=None), registry()))
+
+    def test_a_supplied_timezone_is_applied(self) -> None:
+        observations = list(
+            observations_from_frame(frame(tz=None), registry(), tz=LISBON)
+        )
+        assert all(obs.timestamp.tzinfo is not None for obs in observations)
+        assert observations[0].timestamp.utcoffset() is not None
+
+    def test_a_non_timestamp_index_is_refused(self) -> None:
+        data = frame().reset_index(drop=True)
+        with pytest.raises(LegacyConversionError, match="indexed by timestamp"):
+            list(observations_from_frame(data, registry()))
+
+    def test_an_empty_registry_yields_nothing(self) -> None:
+        observations = list(
+            observations_from_frame(frame(), SensorRegistry(), skip_unregistered=True)
+        )
+        assert observations == []
+
+    def test_converted_records_survive_registry_normalisation(self) -> None:
+        deployment = registry()
+        for observation in observations_from_frame(frame(), deployment):
+            assert deployment.normalise(observation) is not None
+
+
+class TestDatasetAndRecords:
+    def test_a_legacy_dataset_converts(self) -> None:
+        dataset = SensorDataset(frame())
+        observations = list(observations_from_dataset(dataset, registry()))
+        assert observations
+        assert all(obs.timestamp.tzinfo is not None for obs in observations)
+
+    def test_an_object_without_to_dataframe_is_refused(self) -> None:
+        with pytest.raises(LegacyConversionError, match="to_dataframe"):
+            list(observations_from_dataset(object(), registry()))
+
+    def test_long_format_records_convert(self) -> None:
+        records = [
+            {"timestamp": T0, "sensor_id": "kitchen_motion", "value": 1.0},
+            {
+                "timestamp": T0 + timedelta(minutes=5),
+                "sensor_id": "hall_temp",
+                "value": 21.0,
+            },
+        ]
+        observations = list(observations_from_records(records, registry()))
+        assert [o.sensor_id for o in observations] == ["kitchen_motion", "hall_temp"]
+        assert observations[1].unit is Unit.CELSIUS
+
+    def test_malformed_records_are_refused(self) -> None:
+        with pytest.raises(LegacyConversionError, match="mapping"):
+            list(observations_from_records([("not", "a", "mapping")], registry()))
+
+    def test_naive_utc_is_an_explicit_opt_in(self) -> None:
+        naive = datetime(2024, 5, 1, 8, 0)
+        assert naive_utc(naive).tzinfo is timezone.utc
+        assert naive_utc(T0) is T0
+
+
+class TestRoundTrip:
+    def test_framing_recovers_the_event_counts_it_started_from(self) -> None:
+        """A wide frame converted to observations and framed back must not
+        gain or lose activations."""
+        from sensor_modeling.observations import ObservationStream
+
+        original = frame()
+        stream = ObservationStream.from_observations(
+            observations_from_frame(original, registry())
+        )
+        counts = stream.event_counts("15min", sensor_ids=["kitchen_motion"])
+        assert counts["kitchen_motion"].sum() == original["kitchen_motion"].sum()


### PR DESCRIPTION
Converters from legacy wide frames, datasets and long-format records into canonical observations. Requires a registry rather than guessing modality from column names; refuses naive timestamps; drops zeros in event columns since those are absent records, not observations of nothing.

Adds property-based tests for observation and stream invariants, plus a docs page showing four unlike sensors reaching one pipeline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds adapters that convert legacy wide frames, datasets, and long-format records into canonical observations. The converters require a `SensorRegistry` so modality and semantics are explicit, refuse naive timestamps without an explicit timezone, and drop zeros in event columns because those are absent records, not observations. Also adds property-based tests for observation and stream invariants and a docs page showing four unlike sensors reaching one pipeline.

<sup>Written for commit c55d9090d6742299410e0914c2242bbcbf91a52c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/62?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

