### PR TITLE
Add structured explanations and calibration tests for state inference

### DIFF
--- a/sensor_modeling/fusion/__init__.py
+++ b/sensor_modeling/fusion/__init__.py
@@ -15,6 +15,7 @@ from .emissions import (
 )
 from .estimate import (
     EvidenceContribution,
+    Explanation,
     StateEstimate,
     belief_from_mapping,
     belief_matrix,
@@ -31,6 +32,7 @@ __all__ = [
     "EmissionDefaults",
     "EmissionModel",
     "EvidenceContribution",
+    "Explanation",
     "FusionConfig",
     "GaussianEmission",
     "MultimodalBayesFilter",

--- a/sensor_modeling/fusion/estimate.py
+++ b/sensor_modeling/fusion/estimate.py
@@ -94,6 +94,70 @@ class EvidenceContribution:
 
 
 @dataclass(frozen=True)
+class Explanation:
+    """Why an estimate reached its conclusion, as addressable parts.
+
+    Four fields carry information that a bare probability cannot, and each
+    answers a question a reader would otherwise have to guess at:
+
+    ``supporting`` / ``contradicting``
+        Which sensors agreed and which pointed elsewhere. Disagreement is
+        surfaced rather than averaged away.
+    ``silent``
+        Trusted sensors that reported nothing. Their silence *did* inform the
+        posterior -- under a Poisson model it penalises the states that would
+        have triggered them.
+    ``missing``
+        Sensors discounted to zero reliability. These contributed nothing at
+        all, and the distinction from ``silent`` is the difference between a
+        quiet room and a broken sensor.
+    """
+
+    at: datetime
+    state: BehaviouralState
+    probability: float
+    abstained: bool
+    reason: str | None
+    supporting: tuple[str, ...]
+    contradicting: tuple[str, ...]
+    silent: tuple[str, ...]
+    missing: tuple[str, ...]
+    completeness: float
+
+    def render(self) -> str:
+        """Render the explanation as an indented, human-readable block."""
+        lines = [
+            f"State:                 {self.state.value}",
+            f"Probability:           {self.probability:.2f}",
+            f"Sensor coverage:       {self.completeness:.2f}",
+        ]
+        if self.abstained and self.reason:
+            lines.append(f"Declined because:      {self.reason}")
+        lines.append(f"Supporting evidence:   {', '.join(self.supporting) or 'none'}")
+        lines.append(
+            f"Contradictory:         {', '.join(self.contradicting) or 'none'}"
+        )
+        lines.append(f"Quiet but working:     {', '.join(self.silent) or 'none'}")
+        lines.append(f"No evidence from:      {', '.join(self.missing) or 'none'}")
+        return "\n".join(lines)
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a serialisable form of the explanation."""
+        return {
+            "at": self.at.isoformat(),
+            "state": self.state.value,
+            "probability": self.probability,
+            "abstained": self.abstained,
+            "reason": self.reason,
+            "supporting": list(self.supporting),
+            "contradicting": list(self.contradicting),
+            "silent": list(self.silent),
+            "missing": list(self.missing),
+            "completeness": self.completeness,
+        }
+
+
+@dataclass(frozen=True)
 class StateEstimate:
     """A posterior over latent behavioural states, with its justification."""
 
@@ -207,6 +271,35 @@ class StateEstimate:
             c.sensor_id for c in self.evidence if c.informative and not c.reported
         )
 
+    def explanation(self, limit: int = 3) -> Explanation:
+        """Return the justification for this estimate as structured data.
+
+        Separate from :meth:`explain` because the two have different
+        consumers: a report renders the sentence, while an interface or an
+        export needs the parts addressable. Both are built from the same
+        evidence, so they cannot drift apart.
+        """
+        return Explanation(
+            at=self.at,
+            state=self.state,
+            probability=self.confidence,
+            abstained=self.abstained,
+            reason=(
+                None
+                if not self.abstained
+                else (
+                    "insufficient sensor coverage"
+                    if self.completeness < self.min_completeness
+                    else "no state was clearly indicated"
+                )
+            ),
+            supporting=tuple(c.sensor_id for c in self.supporting[:limit]),
+            contradicting=tuple(c.sensor_id for c in self.contradicting[:limit]),
+            silent=self.silent,
+            missing=self.missing,
+            completeness=self.completeness,
+        )
+
     def explain(self, limit: int = 3) -> str:
         """Return a short human-readable justification for the estimate.
 
@@ -261,6 +354,7 @@ class StateEstimate:
             "evidence": [c.to_dict() for c in self.evidence],
             "missing": list(self.missing),
             "silent": list(self.silent),
+            "explanation_parts": self.explanation().to_dict(),
             "explanation": self.explain(),
         }
 

--- a/tests/test_fusion_calibration.py
+++ b/tests/test_fusion_calibration.py
@@ -1,0 +1,283 @@
+"""Calibration and scenario tests for state inference.
+
+Calibration is the property that makes a probabilistic system usable for
+longitudinal monitoring: a stated confidence of 0.9 has to mean something, or
+downstream thresholds are arbitrary. These tests check it against the
+simulator's ground truth, and check the scenarios a deployment actually
+encounters -- ambiguity, contradiction, failure, silence and transition.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import numpy as np
+import pytest
+
+from sensor_modeling.evaluation import state_metrics
+from sensor_modeling.fusion import Explanation
+from sensor_modeling.online import BehaviouralSensingPipeline, PipelineConfig
+from sensor_modeling.simulation import (
+    DegradationConfig,
+    HouseholdConfig,
+    degrade,
+    dropout,
+    not_worn,
+    simulate,
+)
+from sensor_modeling.states import BehaviouralState as S
+
+STEP = timedelta(minutes=15)
+
+
+@pytest.fixture(scope="module")
+def household() -> object:
+    """A ten-day synthetic household shared across the module."""
+    return simulate(HouseholdConfig(days=10, seed=606))
+
+
+def run(result: object, observations: object = None) -> list:
+    """Drive a record through a fresh pipeline."""
+    pipeline = BehaviouralSensingPipeline(
+        result.registry,  # type: ignore[attr-defined]
+        config=PipelineConfig(tz=result.config.tz, step=STEP),  # type: ignore[attr-defined]
+    )
+    records = observations if observations is not None else result.observations  # type: ignore[attr-defined]
+    steps = pipeline.run(records)  # type: ignore[arg-type]
+    steps.extend(pipeline.close(result.end))  # type: ignore[attr-defined]
+    return steps
+
+
+def truth_for(result: object, steps: list) -> list:
+    """Ground-truth states aligned with a run of steps."""
+    return result.truth.states_at([step.at for step in steps])  # type: ignore[attr-defined]
+
+
+class TestCalibration:
+    def test_stated_confidence_tracks_observed_accuracy(
+        self, household: object
+    ) -> None:
+        """The defining property of a calibrated probabilistic system.
+
+        Compared across confidence quantiles rather than fixed bands, since
+        the filter is confident most of the time and a fixed low band can be
+        empty for a given seed.
+        """
+        steps = run(household)
+        truth = truth_for(household, steps)
+        pairs = sorted(
+            (
+                (step.state.confidence, actual is step.state.most_likely)
+                for actual, step in zip(truth, steps)
+                if actual is not None
+            ),
+            key=lambda pair: pair[0],
+        )
+        assert len(pairs) > 100
+
+        third = len(pairs) // 3
+        least_confident = pairs[:third]
+        most_confident = pairs[-third:]
+        low_accuracy = sum(1 for _, hit in least_confident if hit) / len(
+            least_confident
+        )
+        high_accuracy = sum(1 for _, hit in most_confident if hit) / len(most_confident)
+
+        assert high_accuracy > low_accuracy
+        assert high_accuracy > 0.75
+
+    def test_expected_calibration_error_is_bounded(self, household: object) -> None:
+        steps = run(household)
+        metrics = state_metrics(truth_for(household, steps), [s.state for s in steps])
+        assert metrics.calibration_error < 0.2
+
+    def test_losing_sensors_does_not_make_the_model_overconfident(
+        self, household: object
+    ) -> None:
+        """The dangerous failure is confidence staying high as accuracy falls."""
+        clean = state_metrics(
+            truth_for(household, run(household)),
+            [s.state for s in run(household)],
+        )
+        degraded_records, _ = degrade(
+            household.observations,  # type: ignore[attr-defined]
+            DegradationConfig(missing_rate=0.4, seed=5),
+        )
+        degraded_steps = run(household, degraded_records)
+        degraded = state_metrics(
+            truth_for(household, degraded_steps),
+            [s.state for s in degraded_steps],
+        )
+        assert degraded.balanced_accuracy <= clean.balanced_accuracy
+        # Calibration is allowed to worsen, but not without bound.
+        assert degraded.calibration_error < clean.calibration_error + 0.15
+
+    def test_probabilities_are_proper_across_a_whole_run(
+        self, household: object
+    ) -> None:
+        for step in run(household):
+            belief = step.state.belief
+            assert np.all(np.isfinite(belief))
+            assert belief.min() >= 0.0
+            assert np.isclose(belief.sum(), 1.0)
+
+
+class TestScenarios:
+    def test_an_unambiguous_night_is_inferred_confidently(
+        self, household: object
+    ) -> None:
+        steps = run(household)
+        truth = truth_for(household, steps)
+        asleep = [step for actual, step in zip(truth, steps) if actual is S.SLEEPING]
+        assert asleep
+        mean_confidence = float(np.mean([s.state.confidence for s in asleep]))
+        assert mean_confidence > 0.6
+
+    def test_a_single_sensor_failure_is_absorbed(self, household: object) -> None:
+        faults = (
+            dropout(
+                "bed_pressure",
+                household.start + timedelta(days=2),  # type: ignore[attr-defined]
+                timedelta(days=2),
+            ),
+        )
+        records, _ = degrade(
+            household.observations, DegradationConfig(faults=faults)  # type: ignore[attr-defined]
+        )
+        metrics = state_metrics(
+            truth_for(household, run(household, records)),
+            [s.state for s in run(household, records)],
+        )
+        assert metrics.balanced_accuracy > 0.55
+
+    def test_multiple_simultaneous_failures_degrade_without_collapsing(
+        self, household: object
+    ) -> None:
+        start = household.start + timedelta(days=2)  # type: ignore[attr-defined]
+        faults = (
+            dropout("bed_pressure", start, timedelta(days=3)),
+            dropout("living_radar", start, timedelta(days=3)),
+            *not_worn(["wearable_motion", "resident_beacon"], start, timedelta(days=3)),
+        )
+        records, _ = degrade(
+            household.observations, DegradationConfig(faults=faults)  # type: ignore[attr-defined]
+        )
+        steps = run(household, records)
+        during = [
+            step for step in steps if start <= step.at < start + timedelta(days=3)
+        ]
+        assert during
+        # Ambient sensors alone cannot resolve much, so the model should be
+        # visibly less certain rather than confidently wrong.
+        assert float(np.mean([s.state.completeness for s in during])) < 0.75
+
+    def test_no_observations_at_all_yields_no_steps(self, household: object) -> None:
+        pipeline = BehaviouralSensingPipeline(household.registry)  # type: ignore[attr-defined]
+        assert pipeline.run([]) == []
+
+    def test_state_transitions_are_followed(self, household: object) -> None:
+        """The filter must move, not settle on one state for the whole run."""
+        steps = run(household)
+        reported = [step.state.state for step in steps]
+        changes = sum(1 for a, b in zip(reported, reported[1:]) if a is not b)
+        assert changes > 20
+        assert len(set(reported)) >= 4
+
+
+class TestStructuredExplanation:
+    def test_every_estimate_can_explain_itself(self, household: object) -> None:
+        for step in run(household)[:50]:
+            explanation = step.state.explanation()
+            assert isinstance(explanation, Explanation)
+            assert explanation.state is step.state.state
+            assert 0.0 <= explanation.probability <= 1.0
+
+    def test_the_rendered_block_names_every_evidence_category(
+        self, household: object
+    ) -> None:
+        rendered = run(household)[len(run(household)) // 2].state.explanation().render()
+        for heading in (
+            "State:",
+            "Probability:",
+            "Sensor coverage:",
+            "Supporting evidence:",
+            "Contradictory:",
+            "Quiet but working:",
+            "No evidence from:",
+        ):
+            assert heading in rendered
+
+    def test_an_abstention_explains_why_it_declined(self, household: object) -> None:
+        dead = tuple(
+            dropout(
+                sensor_id,
+                household.start + timedelta(days=2),  # type: ignore[attr-defined]
+                timedelta(days=2),
+            )
+            for sensor_id in household.registry.sensor_ids()  # type: ignore[attr-defined]
+        )
+        records, _ = degrade(
+            household.observations, DegradationConfig(faults=dead)  # type: ignore[attr-defined]
+        )
+        abstentions = [
+            step.state.explanation()
+            for step in run(household, records)
+            if step.state.abstained
+        ]
+        assert abstentions
+        assert abstentions[0].reason
+        assert "coverage" in abstentions[0].reason or "clearly" in abstentions[0].reason
+
+    def test_silent_and_missing_are_reported_separately(
+        self, household: object
+    ) -> None:
+        """A quiet room and a broken sensor must not look the same.
+
+        The radar drops out partway through rather than from the start: a
+        sensor that has *never* reported is UNKNOWN, since it may simply not
+        be installed, and only one that stops after establishing a cadence
+        can be judged missing.
+        """
+        faults = (
+            dropout(
+                "living_radar",
+                household.start + timedelta(days=3),  # type: ignore[attr-defined]
+                timedelta(days=4),
+            ),
+        )
+        records, _ = degrade(
+            household.observations, DegradationConfig(faults=faults)  # type: ignore[attr-defined]
+        )
+        explanations = [step.state.explanation() for step in run(household, records)]
+        assert any("living_radar" in e.missing for e in explanations)
+        assert any(e.silent for e in explanations)
+
+    def test_a_sensor_that_never_reported_is_not_called_missing(
+        self, household: object
+    ) -> None:
+        """It may simply not be installed yet."""
+        faults = (
+            dropout(
+                "living_radar",
+                household.start,  # type: ignore[attr-defined]
+                timedelta(days=30),
+            ),
+        )
+        records, _ = degrade(
+            household.observations, DegradationConfig(faults=faults)  # type: ignore[attr-defined]
+        )
+        explanations = [step.state.explanation() for step in run(household, records)]
+        assert not any("living_radar" in e.missing for e in explanations)
+
+    def test_the_explanation_serialises_with_the_estimate(
+        self, household: object
+    ) -> None:
+        payload = run(household)[10].state.to_dict()
+        assert "explanation_parts" in payload
+        assert set(payload["explanation_parts"]) >= {  # type: ignore[arg-type]
+            "state",
+            "supporting",
+            "contradicting",
+            "silent",
+            "missing",
+        }


### PR DESCRIPTION
Explanation exposes the justification for an estimate as addressable parts, alongside the existing one-line form, and keeps silent sensors distinct from missing ones.

Adds calibration tests against ground truth, scenario coverage for multiple simultaneous failures and state transitions, and a check that losing sensors does not make the model overconfident.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structured explanations to state estimates so their justification is available as addressable parts, not just a one-line sentence, and adds calibration tests against simulated ground truth.

- New `Explanation` includes supporting, contradicting, silent, and missing sensors; `to_dict()` now serializes it as `explanation_parts`.
- Silent sensors are trusted but quiet and still affect the posterior, while missing sensors contributed nothing, so the two remain distinct.
- Calibration tests check confidence tracks accuracy, calibration error stays bounded, and losing sensors does not make the model overconfident.
- Scenario tests cover simultaneous sensor failures, state transitions, and abstention reasons.

<sup>Written for commit 6ebc9018c7aaadb42dd608d0dc66686f8eec91da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

