### PR TITLE
Compare naive against occupancy-aware activity attribution

### DIFF
--- a/sensor_modeling/cli.py
+++ b/sensor_modeling/cli.py
@@ -77,6 +77,75 @@ def _add_ablation_parser(sub: argparse._SubParsersAction) -> None:
     )
 
 
+def _add_attribution_parser(sub: argparse._SubParsersAction) -> None:
+    """Register the attribution comparison experiment."""
+    study = sub.add_parser(
+        "attribution",
+        help="Compare naive against occupancy-aware activity attribution",
+        description=(
+            "Run the same simulated households twice -- once attributing all "
+            "ambient activity to the resident, once discounting it by the "
+            "probability the resident generated it -- and report the difference."
+        ),
+    )
+    study.add_argument("--days", type=int, default=10, help="Days per scenario")
+    study.add_argument("--seed", type=int, default=4242, help="Random seed")
+    study.add_argument(
+        "--step-minutes", type=int, default=15, help="Inference step in minutes"
+    )
+    study.add_argument(
+        "--output", type=Path, default=None, help="Write structured results as JSON"
+    )
+
+
+def _run_attribution(args: argparse.Namespace) -> None:
+    """Dispatch the attribution comparison experiment."""
+    from .evaluation.attribution import run_attribution_study, standard_scenarios
+
+    study = run_attribution_study(
+        standard_scenarios(days=args.days, seed=args.seed),
+        step=timedelta(minutes=args.step_minutes),
+    )
+
+    print("\nNaive against occupancy-aware attribution")
+    print("Both arms see identical households, visitors and sensor records.\n")
+    print(
+        f"{'scenario':<28}{'contam':>8}{'naive':>8}{'aware':>8}"
+        f"{'gain':>8}{'calib':>8}{'visF1':>7}"
+    )
+    for comparison in study.comparisons:
+        print(
+            f"{comparison.scenario:<28}"
+            f"{comparison.contaminated_fraction:>8.3f}"
+            f"{comparison.naive.states.balanced_accuracy:>8.3f}"
+            f"{comparison.occupancy_aware.states.balanced_accuracy:>8.3f}"
+            f"{comparison.balanced_accuracy_gain:>+8.3f}"
+            f"{comparison.calibration_gain:>+8.3f}"
+            f"{comparison.visitor_detection.f1:>7.2f}"
+        )
+
+    contaminated = study.contaminated
+    if contaminated:
+        mean_gain = sum(c.balanced_accuracy_gain for c in contaminated) / len(
+            contaminated
+        )
+        print(
+            "\nMean balanced-accuracy gain where another person was present: "
+            f"{mean_gain:+.4f}"
+        )
+    print(
+        "\nA gain of zero in an uncontaminated scenario is the expected result: "
+        "attribution should be a no-op when nobody else is in the home."
+    )
+
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(study.to_dict(), indent=2, default=str), encoding="utf-8"
+        )
+        print(f"Structured results written to {args.output}")
+
+
 def _run_demo(args: argparse.Namespace) -> None:
     """Dispatch the end-to-end demonstration."""
     from .examples.demos.ambient_pipeline_demo import run_demo
@@ -205,6 +274,7 @@ def main() -> None:
     _add_model_parsers(sub)
     _add_demo_parser(sub)
     _add_ablation_parser(sub)
+    _add_attribution_parser(sub)
 
     args = parser.parse_args()
     setup_logging()
@@ -214,6 +284,8 @@ def main() -> None:
         _run_demo(args)
     elif args.model == "ablate":
         _run_ablation(args)
+    elif args.model == "attribution":
+        _run_attribution(args)
     else:
         _run_model(args, parser)
 

--- a/sensor_modeling/evaluation/__init__.py
+++ b/sensor_modeling/evaluation/__init__.py
@@ -16,6 +16,15 @@ from .ablation import (
     named_subsets,
     run_ablation,
 )
+from .attribution import (
+    ArmResult,
+    AttributionStudy,
+    Scenario,
+    ScenarioComparison,
+    compare_scenario,
+    run_attribution_study,
+    standard_scenarios,
+)
 from .metrics import (
     BinaryMetrics,
     DetectionMetrics,
@@ -32,20 +41,27 @@ from .metrics import (
 
 __all__ = [
     "AblationReport",
+    "ArmResult",
+    "AttributionStudy",
     "AblationRun",
     "BinaryMetrics",
     "DetectionMetrics",
     "PairedDifference",
+    "Scenario",
+    "ScenarioComparison",
     "SensorConfiguration",
     "StateMetrics",
     "TimingMetrics",
     "binary_metrics",
+    "compare_scenario",
     "detection_metrics",
     "evaluate_configuration",
     "leave_one_out",
     "named_subsets",
     "paired_difference",
     "run_ablation",
+    "run_attribution_study",
+    "standard_scenarios",
     "state_metrics",
     "summarise",
     "transition_timing",

--- a/sensor_modeling/evaluation/attribution.py
+++ b/sensor_modeling/evaluation/attribution.py
@@ -1,0 +1,299 @@
+"""Measuring what person attribution is worth.
+
+Most ambient monitoring implicitly attributes every event to the monitored
+resident. This module makes that assumption testable by running the same
+simulated household twice on identical trajectories -- once attributing all
+ambient activity to the resident, once discounting it by the probability that
+the resident actually generated it -- and reporting the difference.
+
+The comparison is paired by construction. Both arms see the same household,
+the same visitors and the same sensor record, so any difference is
+attributable to attribution and to nothing else.
+
+A negative result is meaningful here. If occupancy-aware attribution changes
+nothing, either contamination is negligible in this simulator or the occupancy
+model is too weak to exploit it, and both are worth knowing.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field, replace
+from datetime import timedelta
+from typing import Any
+
+import numpy as np
+
+from ..online.pipeline import BehaviouralSensingPipeline, PipelineConfig
+from ..simulation.faults import DegradationConfig, degrade, dropout, not_worn
+from ..simulation.household import HouseholdConfig, simulate
+from .metrics import BinaryMetrics, StateMetrics, binary_metrics, state_metrics
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Scenario:
+    """A named occupancy situation to evaluate attribution against."""
+
+    name: str
+    household: HouseholdConfig
+    degradation: DegradationConfig | None = None
+    description: str = ""
+
+    def build(self) -> Any:
+        """Simulate the scenario and return the result plus its record."""
+        result = simulate(self.household)
+        observations: Sequence[Any] = result.observations
+        if self.degradation is not None:
+            observations, _ = degrade(observations, self.degradation)
+        return result, observations
+
+
+def standard_scenarios(days: int = 10, seed: int = 4242) -> list[Scenario]:
+    """Build the occupancy situations attribution has to cope with.
+
+    Each isolates one way in which ambient activity can fail to belong to the
+    monitored resident, or one way the evidence for deciding that can be lost.
+    """
+    base = HouseholdConfig(days=days, seed=seed)
+    start = simulate(HouseholdConfig(days=1, seed=seed)).start
+
+    return [
+        Scenario(
+            "resident_alone",
+            replace(base, visitor_probability=0.0, carer_weekday_visits=False),
+            description="No other person ever enters. Attribution should be a no-op.",
+        ),
+        Scenario(
+            "resident_goes_out",
+            replace(
+                base,
+                visitor_probability=0.0,
+                carer_weekday_visits=False,
+                outing_probability=0.95,
+            ),
+            description="The resident is frequently away; ambient events then "
+            "belong to nobody.",
+        ),
+        Scenario(
+            "short_visitor",
+            replace(base, visitor_probability=0.5, carer_weekday_visits=False),
+            description="Occasional short social visits.",
+        ),
+        Scenario(
+            "prolonged_visitor",
+            replace(base, visitor_probability=1.0, carer_weekday_visits=False),
+            description="A visitor present on every day of the record.",
+        ),
+        Scenario(
+            "carer_visits",
+            replace(base, visitor_probability=0.0, carer_weekday_visits=True),
+            description="A regular weekday carer round, the case most likely "
+            "to be mistaken for the resident rising early.",
+        ),
+        Scenario(
+            "visitor_and_carer",
+            replace(base, visitor_probability=0.6, carer_weekday_visits=True),
+            description="Both, so ambient sensors across several rooms are "
+            "contaminated.",
+        ),
+        Scenario(
+            "resident_without_wearable",
+            base,
+            DegradationConfig(
+                faults=not_worn(
+                    ["wearable_motion", "resident_beacon"], start, timedelta(days=days)
+                ),
+                seed=seed + 1,
+            ),
+            description="The strongest attribution evidence is unavailable for "
+            "the whole record.",
+        ),
+        Scenario(
+            "no_radar",
+            base,
+            DegradationConfig(
+                faults=(dropout("living_radar", start, timedelta(days=days)),),
+                seed=seed + 2,
+            ),
+            description="No track count, so multi-person evidence is limited to "
+            "concurrent room activity.",
+        ),
+        Scenario(
+            "sparse_coverage",
+            base,
+            DegradationConfig(missing_rate=0.3, seed=seed + 3),
+            description="Incomplete sensor coverage on top of contamination.",
+        ),
+    ]
+
+
+@dataclass(frozen=True)
+class ArmResult:
+    """Outcome of one attribution setting on one scenario."""
+
+    attributed: bool
+    states: StateMetrics
+    mean_attribution: float
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a serialisable form of the arm."""
+        return {
+            "attributed": self.attributed,
+            "mean_attribution": self.mean_attribution,
+            "states": self.states.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class ScenarioComparison:
+    """Naive against occupancy-aware attribution on one scenario."""
+
+    scenario: str
+    description: str
+    naive: ArmResult
+    occupancy_aware: ArmResult
+    visitor_detection: BinaryMetrics
+    contaminated_fraction: float
+
+    @property
+    def balanced_accuracy_gain(self) -> float:
+        """Balanced accuracy gained by discounting unattributable evidence."""
+        return (
+            self.occupancy_aware.states.balanced_accuracy
+            - self.naive.states.balanced_accuracy
+        )
+
+    @property
+    def calibration_gain(self) -> float:
+        """Reduction in calibration error. Positive means better calibrated."""
+        return (
+            self.naive.states.calibration_error
+            - self.occupancy_aware.states.calibration_error
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a serialisable form of the comparison."""
+        return {
+            "scenario": self.scenario,
+            "description": self.description,
+            "contaminated_fraction": self.contaminated_fraction,
+            "balanced_accuracy_gain": self.balanced_accuracy_gain,
+            "calibration_gain": self.calibration_gain,
+            "visitor_detection": self.visitor_detection.to_dict(),
+            "naive": self.naive.to_dict(),
+            "occupancy_aware": self.occupancy_aware.to_dict(),
+        }
+
+
+def _run_arm(
+    result: Any,
+    observations: Sequence[Any],
+    *,
+    attribute: bool,
+    step: timedelta,
+) -> tuple[ArmResult, list[Any]]:
+    """Run one attribution setting over a prepared record."""
+    pipeline = BehaviouralSensingPipeline(
+        result.registry,
+        config=PipelineConfig(
+            tz=result.config.tz, step=step, attribute_activity=attribute
+        ),
+    )
+    steps = pipeline.run(observations)
+    steps.extend(pipeline.close(result.end))
+    if not steps:
+        raise ValueError("scenario produced no pipeline steps")
+
+    truth = result.truth.states_at([s.at for s in steps])
+    shares = [
+        contribution.attribution
+        for s in steps
+        for contribution in s.state.evidence
+        if contribution.attribution < 1.0 or not attribute
+    ]
+    return (
+        ArmResult(
+            attributed=attribute,
+            states=state_metrics(truth, [s.state for s in steps]),
+            mean_attribution=float(np.mean(shares)) if shares else 1.0,
+        ),
+        steps,
+    )
+
+
+def compare_scenario(
+    scenario: Scenario, *, step: timedelta = timedelta(minutes=10)
+) -> ScenarioComparison:
+    """Run both attribution arms over one scenario and report the difference."""
+    result, observations = scenario.build()
+
+    naive, _ = _run_arm(result, observations, attribute=False, step=step)
+    aware, aware_steps = _run_arm(result, observations, attribute=True, step=step)
+
+    moments = [s.at for s in aware_steps]
+    truth_visitor = [result.truth.visitor_at(moment) for moment in moments]
+    detection = binary_metrics(
+        truth_visitor, [s.context.visitor_present for s in aware_steps]
+    )
+
+    logger.info(
+        "%-26s balanced accuracy naive %.3f -> aware %.3f",
+        scenario.name,
+        naive.states.balanced_accuracy,
+        aware.states.balanced_accuracy,
+    )
+    return ScenarioComparison(
+        scenario=scenario.name,
+        description=scenario.description,
+        naive=naive,
+        occupancy_aware=aware,
+        visitor_detection=detection,
+        contaminated_fraction=float(np.mean(truth_visitor)),
+    )
+
+
+@dataclass
+class AttributionStudy:
+    """Results of comparing attribution across several scenarios."""
+
+    comparisons: list[ScenarioComparison] = field(default_factory=list)
+
+    def by_name(self, name: str) -> ScenarioComparison:
+        """Return the comparison for one scenario."""
+        for comparison in self.comparisons:
+            if comparison.scenario == name:
+                return comparison
+        raise KeyError(f"no scenario named '{name}'")
+
+    @property
+    def contaminated(self) -> list[ScenarioComparison]:
+        """Scenarios in which another person was actually present."""
+        return [c for c in self.comparisons if c.contaminated_fraction > 0.01]
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a serialisable form of the study."""
+        return {
+            "scenarios": [c.to_dict() for c in self.comparisons],
+            "mean_gain_when_contaminated": (
+                float(np.mean([c.balanced_accuracy_gain for c in self.contaminated]))
+                if self.contaminated
+                else 0.0
+            ),
+        }
+
+
+def run_attribution_study(
+    scenarios: Iterable[Scenario] | None = None,
+    *,
+    step: timedelta = timedelta(minutes=10),
+) -> AttributionStudy:
+    """Compare naive and occupancy-aware attribution across scenarios."""
+    selected = list(scenarios) if scenarios is not None else standard_scenarios()
+    if not selected:
+        raise ValueError("at least one scenario is required")
+    return AttributionStudy(
+        comparisons=[compare_scenario(s, step=step) for s in selected]
+    )

--- a/sensor_modeling/online/pipeline.py
+++ b/sensor_modeling/online/pipeline.py
@@ -79,6 +79,13 @@ class PipelineConfig:
         Behavioural states whose daily hours get an adaptive baseline.
     min_day_coverage, min_day_observed
         Quality a day must reach before it may inform the baseline.
+    attribute_activity
+        Whether ambient evidence is discounted by the probability that the
+        monitored resident generated it. Setting this false makes the
+        pipeline attribute every ambient event to the resident, which is the
+        naive behaviour most ambient monitoring assumes. It exists so that
+        assumption can be *measured* against the occupancy-aware default
+        rather than argued about.
     """
 
     tz: tzinfo | None = None
@@ -92,6 +99,7 @@ class PipelineConfig:
     )
     min_day_coverage: float = 0.5
     min_day_observed: float = 0.6
+    attribute_activity: bool = True
 
     def __post_init__(self) -> None:
         """Validate the pipeline configuration."""
@@ -280,7 +288,11 @@ class BehaviouralSensingPipeline:
 
         context = self.context.update(moment, batch, reliabilities=reliabilities)
         self._last_context = context
-        attribution = self.context.attribution(context)
+        attribution = (
+            self.context.attribution(context)
+            if self.config.attribute_activity
+            else None
+        )
 
         estimate = self.filter.update(
             moment, batch, reliabilities=reliabilities, attribution=attribution

--- a/tests/test_attribution_study.py
+++ b/tests/test_attribution_study.py
@@ -1,0 +1,168 @@
+"""Tests for the naive versus occupancy-aware attribution comparison."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import timedelta
+
+import pytest
+
+from sensor_modeling.evaluation import (
+    Scenario,
+    compare_scenario,
+    run_attribution_study,
+    standard_scenarios,
+)
+from sensor_modeling.online import BehaviouralSensingPipeline, PipelineConfig
+from sensor_modeling.simulation import HouseholdConfig, simulate
+
+STEP = timedelta(minutes=30)
+
+
+def alone(days: int = 4, seed: int = 31) -> Scenario:
+    """A household nobody else ever enters."""
+    return Scenario(
+        "alone",
+        HouseholdConfig(
+            days=days,
+            seed=seed,
+            visitor_probability=0.0,
+            carer_weekday_visits=False,
+        ),
+        description="nobody else present",
+    )
+
+
+def with_carer(days: int = 4, seed: int = 31) -> Scenario:
+    """A household with a regular weekday carer round."""
+    return Scenario(
+        "carer",
+        HouseholdConfig(
+            days=days,
+            seed=seed,
+            visitor_probability=0.0,
+            carer_weekday_visits=True,
+        ),
+        description="weekday carer",
+    )
+
+
+class TestNaiveMode:
+    def test_disabling_attribution_credits_every_event_to_the_resident(self) -> None:
+        """The naive arm must actually be naive, or the comparison is empty."""
+        result = simulate(HouseholdConfig(days=3, seed=9))
+        pipeline = BehaviouralSensingPipeline(
+            result.registry,
+            config=PipelineConfig(
+                tz=result.config.tz, step=STEP, attribute_activity=False
+            ),
+        )
+        steps = pipeline.run(result.observations)
+        assert steps
+        shares = {
+            contribution.attribution
+            for step in steps
+            for contribution in step.state.evidence
+        }
+        assert shares == {1.0}
+
+    def test_the_default_discounts_unattributable_evidence(self) -> None:
+        result = simulate(HouseholdConfig(days=3, seed=9, carer_weekday_visits=True))
+        pipeline = BehaviouralSensingPipeline(
+            result.registry, config=PipelineConfig(tz=result.config.tz, step=STEP)
+        )
+        steps = pipeline.run(result.observations)
+        shares = {
+            contribution.attribution
+            for step in steps
+            for contribution in step.state.evidence
+        }
+        assert any(share < 1.0 for share in shares)
+
+
+class TestComparison:
+    def test_attribution_changes_no_conclusion_when_nobody_else_is_present(
+        self,
+    ) -> None:
+        """The property that shows the mechanism is not just adding noise.
+
+        The conclusions are identical. The probabilities differ by order
+        1e-4, because the occupancy model never becomes *certain* the
+        resident is alone and that residual uncertainty propagates. That is
+        the honest behaviour of a probabilistic layer, not a defect: a model
+        that reached certainty here would be overconfident.
+        """
+        comparison = compare_scenario(alone(), step=STEP)
+        assert comparison.contaminated_fraction == 0.0
+        assert comparison.balanced_accuracy_gain == pytest.approx(0.0, abs=1e-9)
+        assert abs(comparison.calibration_gain) < 1e-3
+        assert comparison.occupancy_aware.mean_attribution > 0.9
+
+    def test_a_contaminated_scenario_is_recognised_as_such(self) -> None:
+        comparison = compare_scenario(with_carer(), step=STEP)
+        assert comparison.contaminated_fraction > 0.0
+
+    def test_both_arms_see_the_same_trajectory(self) -> None:
+        """Pairing is what makes the difference attributable to attribution."""
+        comparison = compare_scenario(with_carer(), step=STEP)
+        assert comparison.naive.states.n == comparison.occupancy_aware.states.n
+
+    def test_the_naive_arm_reports_full_attribution(self) -> None:
+        comparison = compare_scenario(with_carer(), step=STEP)
+        assert comparison.naive.mean_attribution == pytest.approx(1.0)
+
+    def test_a_comparison_serialises(self) -> None:
+        payload = compare_scenario(alone(), step=STEP).to_dict()
+        assert payload["scenario"] == "alone"
+        assert "naive" in payload and "occupancy_aware" in payload
+        assert "visitor_detection" in payload
+
+    def test_results_are_reproducible_from_the_seed(self) -> None:
+        first = compare_scenario(with_carer(), step=STEP).to_dict()
+        second = compare_scenario(with_carer(), step=STEP).to_dict()
+        assert first == second
+
+
+class TestScenarios:
+    def test_the_standard_set_covers_the_named_situations(self) -> None:
+        names = {s.name for s in standard_scenarios()}
+        assert names == {
+            "resident_alone",
+            "resident_goes_out",
+            "short_visitor",
+            "prolonged_visitor",
+            "carer_visits",
+            "visitor_and_carer",
+            "resident_without_wearable",
+            "no_radar",
+            "sparse_coverage",
+        }
+
+    def test_every_scenario_documents_what_it_isolates(self) -> None:
+        assert all(s.description for s in standard_scenarios())
+
+    def test_a_degraded_scenario_withholds_records(self) -> None:
+        scenario = next(
+            s for s in standard_scenarios(days=3) if s.name == "sparse_coverage"
+        )
+        result, observations = scenario.build()
+        assert len(observations) < len(result.observations)
+
+    def test_a_study_reports_the_contaminated_subset(self) -> None:
+        study = run_attribution_study([alone(), with_carer()], step=STEP)
+        assert [c.scenario for c in study.contaminated] == ["carer"]
+        assert "mean_gain_when_contaminated" in study.to_dict()
+
+    def test_looking_up_a_missing_scenario_raises(self) -> None:
+        study = run_attribution_study([alone()], step=STEP)
+        with pytest.raises(KeyError, match="no scenario named"):
+            study.by_name("nonexistent")
+
+    def test_an_empty_study_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="at least one scenario"):
+            run_attribution_study([])
+
+    def test_scenarios_can_be_reconfigured(self) -> None:
+        scenario = alone()
+        longer = replace(scenario, household=replace(scenario.household, days=5))
+        assert longer.household.days == 5


### PR DESCRIPTION
Runs the same simulated households twice on identical trajectories, once crediting every ambient event to the resident and once discounting by the probability they generated it, across nine occupancy situations.

Adds a pipeline flag for the naive mode so the assumption can be measured rather than argued about, and a `sensor-modeling attribution` command. Attribution changes no conclusion when nobody else is present, and helps most during a carer round.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a paired study comparing naive activity attribution (crediting every ambient event to the resident) against occupancy-aware attribution (discounting by the probability the resident generated it) across nine occupancy scenarios. Attribution changes no conclusion when nobody else is present and helps most during a carer round.

**New Features**

- Adds a `attribute_activity` pipeline config flag that, when `False`, disables attribution to reproduce the naive assumption.
- Adds a `sensor-modeling attribution` CLI command that runs the study and can write structured results as JSON.
- Adds a `sensor_modeling.evaluation.attribution` module with scenario builders, comparators, and result types.

<sup>Written for commit 4ce3b50f79c10a03f0634fd4c440d2749e8eb71d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/64?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

