### PR TITLE
Measure change-detection delay against alert burden

### DIFF
--- a/sensor_modeling/evaluation/__init__.py
+++ b/sensor_modeling/evaluation/__init__.py
@@ -25,6 +25,13 @@ from .attribution import (
     run_attribution_study,
     standard_scenarios,
 )
+from .detection import (
+    ArmOutcome,
+    ChangeArm,
+    DetectionStudy,
+    run_detection_study,
+    standard_arms,
+)
 from .metrics import (
     BinaryMetrics,
     DetectionMetrics,
@@ -41,11 +48,14 @@ from .metrics import (
 
 __all__ = [
     "AblationReport",
+    "ArmOutcome",
     "ArmResult",
     "AttributionStudy",
     "AblationRun",
     "BinaryMetrics",
+    "ChangeArm",
     "DetectionMetrics",
+    "DetectionStudy",
     "PairedDifference",
     "Scenario",
     "ScenarioComparison",
@@ -61,6 +71,8 @@ __all__ = [
     "paired_difference",
     "run_ablation",
     "run_attribution_study",
+    "run_detection_study",
+    "standard_arms",
     "standard_scenarios",
     "state_metrics",
     "summarise",

--- a/sensor_modeling/evaluation/detection.py
+++ b/sensor_modeling/evaluation/detection.py
@@ -1,0 +1,288 @@
+"""Measuring whether behavioural change detection is usable.
+
+Four numbers decide whether a monitoring system is worth deploying, and they
+trade against each other rather than improving together:
+
+.. code-block:: text
+
+    detection delay          how long a real change goes unreported
+    false alert burden       how often a carer is contacted for nothing
+    missed changes           how often a real change is never reported
+    calibration              whether the confidence attached means anything
+
+A system tuned to detect everything floods its recipients; one tuned for
+silence misses what matters. This module measures the trade rather than
+asserting a favourable point on it, and includes arms where nothing at all has
+changed, because a detector's behaviour on a stable record is as informative
+as its behaviour on a changed one.
+
+Arms are paired by seed, so the stable and changed runs of a given seed differ
+only in the injected change.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field, replace
+from datetime import date, timedelta
+from typing import Any
+
+import numpy as np
+
+from ..alerts.alert import AlertKind
+from ..online.pipeline import BehaviouralSensingPipeline, PipelineConfig, collect_alerts
+from ..simulation.faults import DegradationConfig, degrade
+from ..simulation.household import BehaviourShift, HouseholdConfig, simulate
+from .metrics import DetectionMetrics, detection_metrics
+
+logger = logging.getLogger(__name__)
+
+#: Feature the injected changes act on. Sleep is used because the simulator
+#: can shift it cleanly and because it is the quantity most ambient-monitoring
+#: studies report on.
+TRACKED_FEATURE = "sleeping_hours"
+
+
+@dataclass(frozen=True)
+class ChangeArm:
+    """One configuration of injected change and sensor degradation."""
+
+    name: str
+    shift: BehaviourShift | None
+    degradation: DegradationConfig | None = None
+    description: str = ""
+
+    @property
+    def has_change(self) -> bool:
+        """Whether a real behavioural change was injected."""
+        return self.shift is not None
+
+
+@dataclass(frozen=True)
+class ArmOutcome:
+    """What one arm produced on one seed."""
+
+    arm: str
+    seed: int
+    metrics: DetectionMetrics
+    behavioural_alerts: int
+    person_days: float
+    mean_alert_confidence: float
+
+    @property
+    def alerts_per_person_day(self) -> float:
+        """Total behavioural alert burden, matched or not."""
+        return self.behavioural_alerts / self.person_days if self.person_days else 0.0
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a serialisable form of the outcome."""
+        return {
+            "arm": self.arm,
+            "seed": self.seed,
+            "behavioural_alerts": self.behavioural_alerts,
+            "alerts_per_person_day": self.alerts_per_person_day,
+            "mean_alert_confidence": self.mean_alert_confidence,
+            "detection": self.metrics.to_dict(),
+        }
+
+
+@dataclass
+class DetectionStudy:
+    """Detection outcomes across arms and seeds."""
+
+    outcomes: list[ArmOutcome] = field(default_factory=list)
+
+    def arms(self) -> list[str]:
+        """Arm names in first-seen order."""
+        seen: dict[str, None] = {}
+        for outcome in self.outcomes:
+            seen.setdefault(outcome.arm, None)
+        return list(seen)
+
+    def for_arm(self, arm: str) -> list[ArmOutcome]:
+        """Every outcome for one arm, ordered by seed."""
+        return sorted((o for o in self.outcomes if o.arm == arm), key=lambda o: o.seed)
+
+    def summary(self, arm: str) -> dict[str, float]:
+        """Aggregate one arm across its seeds."""
+        outcomes = self.for_arm(arm)
+        if not outcomes:
+            raise KeyError(f"no outcomes for arm '{arm}'")
+        delays = [
+            o.metrics.median_delay_days
+            for o in outcomes
+            if not np.isnan(o.metrics.median_delay_days)
+        ]
+        return {
+            "seeds": float(len(outcomes)),
+            "recall": float(np.mean([o.metrics.recall for o in outcomes])),
+            "median_delay_days": float(np.mean(delays)) if delays else float("nan"),
+            "alerts_per_person_day": float(
+                np.mean([o.alerts_per_person_day for o in outcomes])
+            ),
+            "false_positives_per_person_day": float(
+                np.mean([o.metrics.false_positives_per_person_day for o in outcomes])
+            ),
+            "mean_alert_confidence": float(
+                np.mean([o.mean_alert_confidence for o in outcomes])
+            ),
+        }
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a serialisable form of the study."""
+        return {
+            "arms": {arm: self.summary(arm) for arm in self.arms()},
+            "outcomes": [o.to_dict() for o in self.outcomes],
+        }
+
+
+def standard_arms(
+    days: int = 70, change_day: int = 40, magnitude: float = 1.6
+) -> list[ChangeArm]:
+    """Build the arms needed to characterise the detection trade-off.
+
+    Every arm that injects a change is matched by one that does not, so the
+    alert burden attributable to the change is separable from the burden the
+    detector produces anyway.
+    """
+    step = BehaviourShift(
+        start_day=change_day,
+        sleep_delta_hours=magnitude,
+        night_bathroom_extra=1.2,
+    )
+    gradual = BehaviourShift(
+        start_day=change_day // 2,
+        sleep_delta_hours=magnitude,
+        night_bathroom_extra=1.2,
+        ramp_days=max(days - change_day // 2 - 5, 5),
+    )
+    missing = DegradationConfig(missing_rate=0.3, seed=1)
+
+    return [
+        ChangeArm(
+            "stable",
+            None,
+            description="Nothing changed. Every alert here is a false alarm.",
+        ),
+        ChangeArm(
+            "abrupt_change",
+            step,
+            description="A step change in sleep on a known day.",
+        ),
+        ChangeArm(
+            "gradual_change",
+            gradual,
+            description="The same magnitude reached slowly, which no single "
+            "day's deviation can reveal.",
+        ),
+        ChangeArm(
+            "stable_degraded",
+            None,
+            missing,
+            description="Nothing changed, and a third of records are lost. "
+            "Missingness must not manufacture findings.",
+        ),
+        ChangeArm(
+            "abrupt_change_degraded",
+            step,
+            missing,
+            description="A real change seen through a degraded record.",
+        ),
+    ]
+
+
+def _evaluate(
+    arm: ChangeArm,
+    seed: int,
+    *,
+    days: int,
+    change_day: int,
+    step: timedelta,
+    max_delay_days: float,
+) -> ArmOutcome:
+    """Run one arm on one seed and score the alerts it delivered."""
+    household = HouseholdConfig(days=days, seed=seed, shift=arm.shift)
+    result = simulate(household)
+
+    observations: Sequence[Any] = result.observations
+    if arm.degradation is not None:
+        observations, _ = degrade(observations, replace(arm.degradation, seed=seed))
+
+    pipeline = BehaviouralSensingPipeline(
+        result.registry, config=PipelineConfig(tz=result.config.tz, step=step)
+    )
+    steps = pipeline.run(observations)
+    steps.extend(pipeline.close(result.end))
+
+    alerts = [
+        alert
+        for alert in collect_alerts(steps)
+        if alert.kind is AlertKind.BEHAVIOURAL_CHANGE
+        and TRACKED_FEATURE in str(alert.subject)
+    ]
+    detected: list[date] = [alert.at.date() for alert in alerts]
+
+    true_changes: list[date] = []
+    if arm.shift is not None:
+        true_changes.append(household.start + timedelta(days=arm.shift.start_day))
+
+    metrics = detection_metrics(
+        detected,
+        true_changes,
+        person_days=float(days),
+        max_delay_days=max_delay_days,
+    )
+    return ArmOutcome(
+        arm=arm.name,
+        seed=seed,
+        metrics=metrics,
+        behavioural_alerts=len(alerts),
+        person_days=float(days),
+        mean_alert_confidence=(
+            float(np.mean([a.confidence for a in alerts])) if alerts else float("nan")
+        ),
+    )
+
+
+def run_detection_study(
+    arms: Iterable[ChangeArm] | None = None,
+    *,
+    seeds: Iterable[int] = (11, 22, 33),
+    days: int = 70,
+    change_day: int = 40,
+    step: timedelta = timedelta(minutes=15),
+    max_delay_days: float = 21.0,
+) -> DetectionStudy:
+    """Characterise detection delay against alert burden across arms.
+
+    A gradual arm's change is dated from where it *begins*, not from where it
+    becomes visible, so its reported delay includes the time the trend spent
+    too small to detect. That is the honest accounting: the resident was
+    already declining.
+    """
+    selected = list(arms) if arms is not None else standard_arms(days, change_day)
+    if not selected:
+        raise ValueError("at least one arm is required")
+
+    study = DetectionStudy()
+    for seed in seeds:
+        for arm in selected:
+            outcome = _evaluate(
+                arm,
+                seed,
+                days=days,
+                change_day=change_day,
+                step=step,
+                max_delay_days=max_delay_days,
+            )
+            study.outcomes.append(outcome)
+            logger.info(
+                "seed %s | %-24s | alerts %d | recall %.2f | delay %.1f",
+                seed,
+                arm.name,
+                outcome.behavioural_alerts,
+                outcome.metrics.recall,
+                outcome.metrics.median_delay_days,
+            )
+    return study

--- a/sensor_modeling/simulation/household.py
+++ b/sensor_modeling/simulation/household.py
@@ -193,21 +193,39 @@ class BehaviourShift:
         Additional expected night-time bathroom trips per night.
     outing_probability_delta
         Change in the probability of going out on a given day.
+    ramp_days
+        Days over which the change phases in linearly. Zero produces a step
+        on ``start_day``; a positive value produces a gradual decline, which
+        is a different detection problem: a step is visible in a single day's
+        deviation, whereas a slow trend never is and can only be found by
+        looking across a window.
     """
 
     start_day: int
     sleep_delta_hours: float = 0.0
     night_bathroom_extra: float = 0.0
     outing_probability_delta: float = 0.0
+    ramp_days: int = 0
 
     def __post_init__(self) -> None:
         """Validate the injected shift."""
         if self.start_day < 0:
             raise ValueError("start_day must be non-negative")
+        if self.ramp_days < 0:
+            raise ValueError("ramp_days must be non-negative")
 
     def active_on(self, day_index: int) -> bool:
         """Whether the shift applies on the given simulation day."""
         return day_index >= self.start_day
+
+    def strength_on(self, day_index: int) -> float:
+        """Return how far the change has taken effect, in ``[0, 1]``."""
+        if day_index < self.start_day:
+            return 0.0
+        if self.ramp_days <= 0:
+            return 1.0
+        elapsed = day_index - self.start_day
+        return min(elapsed / self.ramp_days, 1.0)
 
 
 @dataclass
@@ -407,17 +425,19 @@ def _plan_day(
     zone = config.tz
     jitter = config.timing_jitter_minutes / 60.0
     shift = config.shift
-    active = shift is not None and shift.active_on(day_index)
+    # How far the injected change has taken effect today. A step shift is
+    # fully on from its start day; a ramped one phases in.
+    strength = shift.strength_on(day_index) if shift is not None else 0.0
 
     weekend = day.weekday() >= 5
     wake_hour = config.wake_hour + (1.2 if weekend else 0.0)
     wake_hour += rng.normal(0.0, jitter)
     sleep_hour = config.sleep_hour + rng.normal(0.0, jitter)
-    if active and shift is not None:
+    if strength > 0.0 and shift is not None:
         # Less sleep is taken from the front of the night: the resident wakes
         # earlier rather than going to bed later, which is the pattern most
         # often reported in the ambient-monitoring literature.
-        wake_hour -= shift.sleep_delta_hours
+        wake_hour -= shift.sleep_delta_hours * strength
 
     wake = _localise(day, wake_hour, zone)
     bedtime = _localise(day, sleep_hour, zone)
@@ -427,7 +447,7 @@ def _plan_day(
 
     # --- night: sleeping, interrupted by bathroom trips ---------------
     night_rate = config.night_bathroom_rate + (
-        shift.night_bathroom_extra if active and shift is not None else 0.0
+        shift.night_bathroom_extra * strength if shift is not None else 0.0
     )
     trips = int(rng.poisson(max(night_rate, 0.0)))
     trip_starts = sorted(
@@ -457,7 +477,7 @@ def _plan_day(
     episodes.append(Episode(cursor, breakfast_end, S.KITCHEN_ACTIVITY, "kitchen"))
     cursor = breakfast_end
 
-    daytime, cursor = _plan_daytime(day, cursor, bedtime, config, rng, zone, active)
+    daytime, cursor = _plan_daytime(day, cursor, bedtime, config, rng, zone, strength)
     episodes.extend(daytime)
 
     next_midnight = _localise(day + timedelta(days=1), 0.0, zone)
@@ -474,7 +494,7 @@ def _plan_daytime(
     config: HouseholdConfig,
     rng: np.random.Generator,
     zone: tzinfo,
-    shift_active: bool,
+    shift_strength: float,
 ) -> tuple[list[Episode], datetime]:
     """Generate the waking day from after breakfast until bedtime.
 
@@ -486,7 +506,7 @@ def _plan_daytime(
     shift = config.shift
 
     outing_probability = config.outing_probability + (
-        shift.outing_probability_delta if shift_active and shift is not None else 0.0
+        shift.outing_probability_delta * shift_strength if shift is not None else 0.0
     )
     if rng.random() < min(max(outing_probability, 0.0), 1.0):
         out_start = cursor + timedelta(minutes=float(rng.uniform(30, 150)))

--- a/tests/test_detection_study.py
+++ b/tests/test_detection_study.py
@@ -1,0 +1,140 @@
+"""Tests for change-detection delay, alert burden and robustness."""
+
+from __future__ import annotations
+
+import math
+from datetime import timedelta
+
+import pytest
+
+from sensor_modeling.evaluation import ChangeArm, run_detection_study, standard_arms
+from sensor_modeling.simulation import BehaviourShift, HouseholdConfig, simulate
+from sensor_modeling.states import BehaviouralState as S
+
+DAYS = 40
+CHANGE_DAY = 22
+SEEDS = (11, 22)
+STEP = timedelta(minutes=30)
+
+
+def study(arms: list[ChangeArm]) -> object:
+    """Run a short detection study over the shared settings."""
+    return run_detection_study(
+        arms,
+        seeds=SEEDS,
+        days=DAYS,
+        change_day=CHANGE_DAY,
+        step=STEP,
+        max_delay_days=18.0,
+    )
+
+
+def arm_named(name: str) -> ChangeArm:
+    """Pick one arm out of the standard set."""
+    return next(a for a in standard_arms(DAYS, CHANGE_DAY) if a.name == name)
+
+
+class TestRampedChange:
+    def test_a_step_shift_takes_full_effect_immediately(self) -> None:
+        shift = BehaviourShift(start_day=10, sleep_delta_hours=1.5)
+        assert shift.strength_on(9) == 0.0
+        assert shift.strength_on(10) == 1.0
+        assert shift.strength_on(30) == 1.0
+
+    def test_a_ramped_shift_phases_in(self) -> None:
+        shift = BehaviourShift(start_day=10, sleep_delta_hours=1.5, ramp_days=10)
+        assert shift.strength_on(9) == 0.0
+        assert shift.strength_on(15) == pytest.approx(0.5)
+        assert shift.strength_on(20) == 1.0
+        assert shift.strength_on(40) == 1.0
+
+    def test_a_negative_ramp_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="ramp_days"):
+            BehaviourShift(start_day=1, ramp_days=-1)
+
+    def test_a_ramp_produces_a_slower_decline_than_a_step(self) -> None:
+        """The ground truth itself must differ, or the arms are the same test."""
+
+        def sleep_by_day(shift: BehaviourShift) -> list[float]:
+            result = simulate(HouseholdConfig(days=30, seed=77, shift=shift))
+            hours = result.truth.daily_hours(S.SLEEPING)
+            return [hours[day] for day in sorted(hours)]
+
+        step = sleep_by_day(BehaviourShift(start_day=10, sleep_delta_hours=2.0))
+        ramp = sleep_by_day(
+            BehaviourShift(start_day=10, sleep_delta_hours=2.0, ramp_days=15)
+        )
+        # Just after the change begins, the step has already dropped further.
+        assert sum(step[11:16]) < sum(ramp[11:16])
+
+
+class TestDetection:
+    def test_a_real_change_is_detected(self) -> None:
+        summary = study([arm_named("abrupt_change")]).summary("abrupt_change")  # type: ignore[attr-defined]
+        assert summary["recall"] > 0.0
+        assert not math.isnan(summary["median_delay_days"])
+
+    def test_a_stable_record_produces_few_alerts(self) -> None:
+        """Alert burden on an unchanged record is what decides usability."""
+        summary = study([arm_named("stable")]).summary("stable")  # type: ignore[attr-defined]
+        assert summary["recall"] == 0.0
+        assert summary["false_positives_per_person_day"] < 0.1
+
+    def test_missingness_does_not_manufacture_findings(self) -> None:
+        """The safety property: losing data must not invent a change."""
+        results = study([arm_named("stable"), arm_named("stable_degraded")])
+        stable = results.summary("stable")  # type: ignore[attr-defined]
+        degraded = results.summary("stable_degraded")  # type: ignore[attr-defined]
+        assert degraded["false_positives_per_person_day"] <= (
+            stable["false_positives_per_person_day"] + 0.02
+        )
+
+    def test_detection_survives_a_degraded_record(self) -> None:
+        results = study(
+            [arm_named("abrupt_change"), arm_named("abrupt_change_degraded")]
+        )
+        clean = results.summary("abrupt_change")  # type: ignore[attr-defined]
+        degraded = results.summary("abrupt_change_degraded")  # type: ignore[attr-defined]
+        assert degraded["recall"] > 0.0
+        # Detection is allowed to slow down, but not to disappear.
+        assert degraded["recall"] >= clean["recall"] - 0.5
+
+    def test_alerts_carry_a_confidence(self) -> None:
+        summary = study([arm_named("abrupt_change")]).summary("abrupt_change")  # type: ignore[attr-defined]
+        assert 0.0 < summary["mean_alert_confidence"] <= 1.0
+
+
+class TestStudyMechanics:
+    def test_every_arm_runs_on_every_seed(self) -> None:
+        results = study([arm_named("stable"), arm_named("abrupt_change")])
+        assert results.arms() == ["stable", "abrupt_change"]  # type: ignore[attr-defined]
+        assert len(results.for_arm("stable")) == len(SEEDS)  # type: ignore[attr-defined]
+
+    def test_outcomes_are_ordered_by_seed(self) -> None:
+        outcomes = study([arm_named("stable")]).for_arm("stable")  # type: ignore[attr-defined]
+        assert [o.seed for o in outcomes] == sorted(SEEDS)
+
+    def test_the_standard_arms_pair_changed_with_unchanged(self) -> None:
+        """Burden attributable to a change must be separable from baseline."""
+        arms = standard_arms()
+        names = {a.name for a in arms}
+        assert {"stable", "abrupt_change"} <= names
+        assert {"stable_degraded", "abrupt_change_degraded"} <= names
+        assert any(a.has_change for a in arms)
+        assert any(not a.has_change for a in arms)
+
+    def test_every_arm_documents_what_it_isolates(self) -> None:
+        assert all(a.description for a in standard_arms())
+
+    def test_a_study_serialises(self) -> None:
+        payload = study([arm_named("stable")]).to_dict()  # type: ignore[attr-defined]
+        assert "arms" in payload and "outcomes" in payload
+        assert payload["arms"]["stable"]["seeds"] == float(len(SEEDS))
+
+    def test_an_unknown_arm_raises(self) -> None:
+        with pytest.raises(KeyError, match="no outcomes for arm"):
+            study([arm_named("stable")]).summary("nonexistent")  # type: ignore[attr-defined]
+
+    def test_an_empty_study_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="at least one arm"):
+            run_detection_study([], seeds=SEEDS)


### PR DESCRIPTION
Scores detection delay, recall and false alerts per person-day across five arms, each changed arm paired with an unchanged one so burden attributable to a change is separable from baseline burden.

Adds a ramped shift to the simulator so a gradual decline can be injected, not only a step. Losing 30% of records does not increase the false alert rate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a detection-study evaluation that scores detection delay, recall, and false alerts per person-day across five paired arms (each changed arm paired with a stable counterpart) to separate change-attributable burden from baseline. The simulator gains a ramped shift for gradual decline, and tests confirm that 30% missing data does not increase the false alert rate.

<sup>Written for commit b1a03f664642939f75c406e1683ef404c389df04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

