### PR TITLE
Record provenance alongside experiment results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage.xml
 .tmp/
 .ipynb_checkpoints/
 docs/_build/
+results/

--- a/sensor_modeling/cli.py
+++ b/sensor_modeling/cli.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import logging
 from datetime import timedelta
 from pathlib import Path
@@ -77,6 +76,26 @@ def _add_ablation_parser(sub: argparse._SubParsersAction) -> None:
     )
 
 
+def _record(
+    experiment: str,
+    *,
+    configuration: dict[str, object],
+    seeds: list[int],
+    results: dict[str, object],
+    notes: list[str] | None = None,
+) -> object:
+    """Wrap a result in the provenance needed to interpret it later."""
+    from .evaluation.provenance import ExperimentRecord
+
+    return ExperimentRecord(
+        experiment=experiment,
+        configuration=configuration,
+        seeds=seeds,
+        results=results,
+        notes=notes or [],
+    )
+
+
 def _add_attribution_parser(sub: argparse._SubParsersAction) -> None:
     """Register the attribution comparison experiment."""
     study = sub.add_parser(
@@ -139,10 +158,22 @@ def _run_attribution(args: argparse.Namespace) -> None:
     )
 
     if args.output is not None:
-        args.output.parent.mkdir(parents=True, exist_ok=True)
-        args.output.write_text(
-            json.dumps(study.to_dict(), indent=2, default=str), encoding="utf-8"
-        )
+        _record(
+            "attribution_comparison",
+            configuration={
+                "days": args.days,
+                "step_minutes": args.step_minutes,
+                "scenarios": [s.scenario for s in study.comparisons],
+            },
+            seeds=[args.seed],
+            results=study.to_dict(),
+            notes=[
+                "Both arms see identical households, visitors and sensor "
+                "records, so any difference is attributable to attribution.",
+            ],
+        ).write(
+            args.output
+        )  # type: ignore[attr-defined]
         print(f"Structured results written to {args.output}")
 
 
@@ -246,11 +277,24 @@ def _run_ablation(args: argparse.Namespace) -> None:
         "simulated households, so these compare sensing rather than residents."
     )
     if args.output is not None:
-        args.output.parent.mkdir(parents=True, exist_ok=True)
-        args.output.write_text(
-            json.dumps(report.to_dict(args.metric), indent=2, default=str),
-            encoding="utf-8",
-        )
+        _record(
+            "sensor_ablation",
+            configuration={
+                "days": args.days,
+                "step_minutes": args.step_minutes,
+                "metric": args.metric,
+                "subsets": {k: list(v) for k, v in ABLATION_SUBSETS.items()},
+            },
+            seeds=report.seeds,
+            results=report.to_dict(args.metric),
+            notes=[
+                "Configurations are evaluated on identical simulated "
+                "households, so differences compare sensing rather than "
+                "residents.",
+            ],
+        ).write(
+            args.output
+        )  # type: ignore[attr-defined]
         print(f"Structured results written to {args.output}")
 
 

--- a/sensor_modeling/evaluation/__init__.py
+++ b/sensor_modeling/evaluation/__init__.py
@@ -45,8 +45,17 @@ from .metrics import (
     summarise,
     transition_timing,
 )
+from .provenance import (
+    METRIC_DEFINITIONS,
+    RESULTS_DIR,
+    ExperimentRecord,
+    environment,
+    load_record,
+)
 
 __all__ = [
+    "METRIC_DEFINITIONS",
+    "RESULTS_DIR",
     "AblationReport",
     "ArmOutcome",
     "ArmResult",
@@ -56,6 +65,7 @@ __all__ = [
     "ChangeArm",
     "DetectionMetrics",
     "DetectionStudy",
+    "ExperimentRecord",
     "PairedDifference",
     "Scenario",
     "ScenarioComparison",
@@ -65,8 +75,10 @@ __all__ = [
     "binary_metrics",
     "compare_scenario",
     "detection_metrics",
+    "environment",
     "evaluate_configuration",
     "leave_one_out",
+    "load_record",
     "named_subsets",
     "paired_difference",
     "run_ablation",

--- a/sensor_modeling/evaluation/provenance.py
+++ b/sensor_modeling/evaluation/provenance.py
@@ -1,0 +1,207 @@
+"""Making an experimental result interpretable without the code that made it.
+
+A JSON file containing ``{"balanced_accuracy": 0.814}`` is nearly worthless six
+months later. Balanced accuracy of what, over which sensors, with which seeds,
+under which version, and computed how? Every one of those has to be recoverable
+from the artefact itself, because the code will have moved on and the person
+reading it may not be the person who ran it.
+
+An :class:`ExperimentRecord` therefore carries the results *and* everything
+needed to interpret and reproduce them: the configuration, the seeds, the
+software and library versions, the sensor subset, and a written definition of
+every metric reported.
+
+Artefacts are written to a results directory that is deliberately excluded
+from version control. Results are regenerated from their seed rather than
+committed, so the repository does not accumulate large generated files.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import platform
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Default location for generated artefacts. Excluded from version control.
+RESULTS_DIR = Path("results")
+
+#: Written definitions of every metric this package reports.
+#:
+#: These travel with the artefact so a stored number can be interpreted
+#: without the source. Where a metric has a convention that could reasonably
+#: go the other way -- notably how abstentions are scored -- the convention is
+#: stated rather than left implicit.
+METRIC_DEFINITIONS: dict[str, str] = {
+    "accuracy": (
+        "Fraction of scored estimates whose reported state equals the true "
+        "state. A reported UNKNOWN is never correct, so abstentions count as "
+        "errors."
+    ),
+    "selective_accuracy": (
+        "Accuracy among only the estimates that committed to a state. Read "
+        "together with abstention_rate."
+    ),
+    "abstention_rate": (
+        "Fraction of estimates that declined to name a state, because "
+        "confidence or sensor coverage fell below threshold."
+    ),
+    "balanced_accuracy": (
+        "Unweighted mean of per-class recall. Used in preference to accuracy "
+        "because the states are heavily imbalanced and a model that always "
+        "predicts the majority state scores highly on raw accuracy."
+    ),
+    "macro_f1": "Unweighted mean F1 across the classes present in the truth.",
+    "log_loss": (
+        "Mean negative log probability assigned to the true state. Punishes "
+        "confident errors far more than hedged ones."
+    ),
+    "brier": (
+        "Multiclass Brier score over the full posterior, in [0, 2]. A proper "
+        "scoring rule; lower is better."
+    ),
+    "calibration_error": (
+        "Expected calibration error: the bin-weighted gap between stated "
+        "confidence and observed accuracy. Answers whether a confidence of "
+        "0.9 means anything."
+    ),
+    "per_class_recall": "Recall for each state present in the ground truth.",
+    "precision": "True positives divided by predicted positives.",
+    "recall": "True positives divided by actual positives.",
+    "f1": "Harmonic mean of precision and recall.",
+    "median_delay_days": (
+        "Median days between a true change occurring and an alert being "
+        "delivered for it. A detection counts only if it falls at or after "
+        "the change and within max_delay_days."
+    ),
+    "false_positives_per_person_day": (
+        "Delivered alerts not matched to a true change, divided by monitored "
+        "person-days. The alert burden a recipient experiences."
+    ),
+    "mean_difference": (
+        "Mean paired difference between two configurations evaluated on "
+        "identical simulated trajectories."
+    ),
+    "ci_low, ci_high": (
+        "Bootstrap confidence interval on the mean paired difference. "
+        "Reported instead of a p-value: with simulations, significance is a "
+        "statement about how long the computer ran."
+    ),
+    "effect_size": (
+        "Cohen's dz for the paired difference. Note that pairing removes "
+        "between-household variance, so dz is larger than an unpaired field "
+        "study of the same size would produce."
+    ),
+    "contaminated_fraction": (
+        "Fraction of simulated time during which someone other than the "
+        "monitored resident was present."
+    ),
+}
+
+
+def environment() -> dict[str, str]:
+    """Capture the software environment a result was produced in."""
+    versions: dict[str, str] = {
+        "python": sys.version.split()[0],
+        "platform": platform.platform(),
+    }
+    for name in ("numpy", "scipy", "pandas", "sensor_modeling"):
+        try:
+            module = __import__(name)
+            versions[name] = str(getattr(module, "__version__", "unknown"))
+        except ImportError:  # pragma: no cover - all are hard dependencies
+            versions[name] = "not installed"
+    return versions
+
+
+@dataclass
+class ExperimentRecord:
+    """A result together with everything needed to interpret and repeat it.
+
+    Parameters
+    ----------
+    experiment
+        Name of the experiment, matching the command that produces it.
+    configuration
+        Every parameter that affects the outcome. A reader must be able to
+        reconstruct the run from this alone.
+    seeds
+        Random seeds used. Listed separately from the configuration because
+        they are the first thing anyone reproducing a result reaches for.
+    results
+        The findings themselves.
+    sensor_subset
+        Sensors the experiment ran over, when it varies them.
+    notes
+        Anything a reader needs in order not to over-read the result.
+    """
+
+    experiment: str
+    configuration: Mapping[str, Any]
+    seeds: Sequence[int] = field(default_factory=list)
+    results: Mapping[str, Any] = field(default_factory=dict)
+    sensor_subset: Sequence[str] | None = None
+    notes: Sequence[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        """Validate that the record is self-describing."""
+        if not str(self.experiment).strip():
+            raise ValueError("an experiment record needs a name")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the full artefact, results and provenance together."""
+        return {
+            "experiment": self.experiment,
+            "recorded_at": datetime.now(timezone.utc).isoformat(),
+            "environment": environment(),
+            "configuration": dict(self.configuration),
+            "seeds": list(self.seeds),
+            "sensor_subset": (
+                list(self.sensor_subset) if self.sensor_subset is not None else None
+            ),
+            "metric_definitions": METRIC_DEFINITIONS,
+            "results": dict(self.results),
+            "notes": [
+                *self.notes,
+                "Generated from the bundled simulator. Not validated against "
+                "real sensor data; see docs/limitations.rst.",
+            ],
+        }
+
+    def write(self, path: Path | None = None) -> Path:
+        """Write the artefact as JSON and return where it went.
+
+        A ``recorded_at`` stamp is added at write time, so two writes of the
+        same record are not byte-identical. The *results* they contain are,
+        which is the property reproducibility actually needs.
+        """
+        target = path if path is not None else RESULTS_DIR / f"{self.experiment}.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(
+            json.dumps(self.to_dict(), indent=2, default=str), encoding="utf-8"
+        )
+        logger.info("Wrote experiment record to %s", target)
+        return target
+
+
+def load_record(path: Path) -> dict[str, Any]:
+    """Read an artefact back, checking it carries its provenance."""
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    missing = [
+        key
+        for key in ("experiment", "environment", "configuration", "metric_definitions")
+        if key not in payload
+    ]
+    if missing:
+        raise ValueError(
+            f"artefact at {path} is missing provenance fields: {sorted(missing)}"
+        )
+    result: dict[str, Any] = payload
+    return result

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,100 @@
+"""Tests that experiment artefacts are interpretable without the code."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sensor_modeling.evaluation import (
+    METRIC_DEFINITIONS,
+    ExperimentRecord,
+    environment,
+    load_record,
+)
+
+
+def record(**overrides: object) -> ExperimentRecord:
+    """Build a record with selective overrides."""
+    payload: dict[str, object] = {
+        "experiment": "example",
+        "configuration": {"days": 10, "step_minutes": 15},
+        "seeds": [1, 2, 3],
+        "results": {"balanced_accuracy": 0.81},
+    }
+    payload.update(overrides)
+    return ExperimentRecord(**payload)  # type: ignore[arg-type]
+
+
+class TestSelfDescription:
+    def test_an_artefact_carries_everything_needed_to_repeat_it(self) -> None:
+        payload = record().to_dict()
+        assert payload["configuration"] == {"days": 10, "step_minutes": 15}
+        assert payload["seeds"] == [1, 2, 3]
+        assert payload["environment"]["python"]
+        assert payload["recorded_at"]
+
+    def test_every_reported_metric_has_a_written_definition(self) -> None:
+        """A bare number is nearly worthless six months later."""
+        payload = record().to_dict()
+        definitions = payload["metric_definitions"]
+        assert "balanced_accuracy" in definitions  # type: ignore[operator]
+        assert "abstention" in definitions["balanced_accuracy"] or len(  # type: ignore[index]
+            definitions["balanced_accuracy"]  # type: ignore[index]
+        )
+
+    def test_the_abstention_convention_is_stated_not_implied(self) -> None:
+        assert "UNKNOWN is never correct" in METRIC_DEFINITIONS["accuracy"]
+
+    def test_the_pairing_caveat_travels_with_the_effect_size(self) -> None:
+        assert "unpaired" in METRIC_DEFINITIONS["effect_size"]
+
+    def test_every_artefact_records_that_it_came_from_a_simulator(self) -> None:
+        notes = record().to_dict()["notes"]
+        assert any("simulator" in note for note in notes)  # type: ignore[union-attr]
+
+    def test_library_versions_are_captured(self) -> None:
+        captured = environment()
+        assert set(captured) >= {"python", "platform", "numpy", "sensor_modeling"}
+
+    def test_a_record_needs_a_name(self) -> None:
+        with pytest.raises(ValueError, match="needs a name"):
+            record(experiment="  ")
+
+    def test_a_sensor_subset_is_recorded_when_it_varies(self) -> None:
+        payload = record(sensor_subset=["door", "bed"]).to_dict()
+        assert payload["sensor_subset"] == ["door", "bed"]
+
+    def test_no_subset_is_recorded_as_such(self) -> None:
+        assert record().to_dict()["sensor_subset"] is None
+
+
+class TestWriteAndLoad:
+    def test_writing_creates_the_directory(self, tmp_path: Path) -> None:
+        target = tmp_path / "nested" / "run.json"
+        assert record().write(target) == target
+        assert target.exists()
+
+    def test_a_written_artefact_round_trips(self, tmp_path: Path) -> None:
+        target = record().write(tmp_path / "run.json")
+        loaded = load_record(target)
+        assert loaded["experiment"] == "example"
+        assert loaded["results"]["balanced_accuracy"] == 0.81
+
+    def test_the_results_are_stable_across_writes(self, tmp_path: Path) -> None:
+        """The timestamp differs; the findings must not."""
+        first = load_record(record().write(tmp_path / "a.json"))
+        second = load_record(record().write(tmp_path / "b.json"))
+        assert first["results"] == second["results"]
+        assert first["configuration"] == second["configuration"]
+
+    def test_an_artefact_without_provenance_is_refused(self, tmp_path: Path) -> None:
+        bare = tmp_path / "bare.json"
+        bare.write_text(json.dumps({"balanced_accuracy": 0.81}), encoding="utf-8")
+        with pytest.raises(ValueError, match="missing provenance fields"):
+            load_record(bare)
+
+    def test_the_artefact_is_json_serialisable(self, tmp_path: Path) -> None:
+        target = record().write(tmp_path / "run.json")
+        assert json.loads(target.read_text(encoding="utf-8"))


### PR DESCRIPTION
Experiment artifacts now carry the configuration, seeds, library versions, sensor subset and a written definition of every metric reported, so a stored number stays interpretable without the code that produced it.

Wired into the ablation and attribution commands. Generated results are gitignored and regenerated from their seed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stores experiment results with the configuration, seeds, library versions, sensor subset, and written definitions of every metric, so a stored number stays interpretable without the code that produced it. The ablation and attribution commands now write these self-describing records instead of bare result JSON.

- `results/` is now gitignored since artifacts are regenerated from their seeds.
- `load_record` rejects any JSON file missing the provenance fields.
- Output file format changes: consumers of the old bare-result JSON must read the `results` key of the new envelope.

<sup>Written for commit 3cd6cae96e4029d814f4f72ff0e3a8689f5e7fb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/66?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

