### PR TITLE
Benchmark online throughput, latency and retained state

### DIFF
--- a/sensor_modeling/online/__init__.py
+++ b/sensor_modeling/online/__init__.py
@@ -5,6 +5,12 @@ knows nothing about files, HTTP, dashboards, or storage, which keeps the
 scientific layers usable without it.
 """
 
+from .benchmarks import (
+    BoundedStateResult,
+    PipelineBenchmark,
+    benchmark_pipeline,
+    measure_bounded_state,
+)
 from .pipeline import (
     BehaviouralSensingPipeline,
     PipelineConfig,
@@ -17,10 +23,14 @@ from .pipeline import (
 
 __all__ = [
     "BehaviouralSensingPipeline",
+    "BoundedStateResult",
+    "PipelineBenchmark",
     "PipelineConfig",
     "PipelineStep",
+    "benchmark_pipeline",
     "collect_alerts",
     "collect_changes",
     "daily_summaries",
     "local_midnight",
+    "measure_bounded_state",
 ]

--- a/sensor_modeling/online/benchmarks.py
+++ b/sensor_modeling/online/benchmarks.py
@@ -1,0 +1,242 @@
+"""Measuring whether the online pipeline is genuinely edge-capable.
+
+Claiming bounded memory is easy; demonstrating it is the point of this module.
+The measurement that matters is not peak allocation on one run -- that varies
+with the interpreter and tells you little -- but whether the *retained* state
+grows with how long the pipeline has been running.
+
+So the central measurement here compares the serialised snapshot after a short
+run against the snapshot after a much longer one. If the pipeline is bounded,
+those are close to the same size no matter how many observations went through.
+If it is quietly accumulating, the second is larger, and no amount of docstring
+prose about bounded deques will hide it.
+
+Correctness came first. Nothing in the pipeline has been optimised, and these
+numbers exist to establish a baseline and catch regressions, not to advertise
+performance.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import tracemalloc
+from dataclasses import dataclass
+from datetime import timedelta
+
+import numpy as np
+
+from ..baseline.adaptive import BaselineConfig
+from ..simulation.household import HouseholdConfig, simulate
+from .pipeline import BehaviouralSensingPipeline, PipelineConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PipelineBenchmark:
+    """Throughput, latency and retained-state measurements for one run.
+
+    Attributes
+    ----------
+    days, observations, steps
+        Size of the workload.
+    wall_seconds
+        Total processing time.
+    observations_per_second
+        Ingestion throughput.
+    microseconds_per_observation
+        Mean cost of admitting one record.
+    step_latency_ms
+        Mean, median, 95th percentile and maximum cost of one pipeline step,
+        which is where health, context, fusion and baselines all run.
+    snapshot_bytes
+        Size of the serialised restartable state. This is the number that
+        decides whether the pipeline fits on a constrained device.
+    peak_memory_mb
+        Peak traced allocation during the run, including the simulated
+        record itself, so it is an upper bound rather than the pipeline's
+        own footprint.
+    """
+
+    days: int
+    observations: int
+    steps: int
+    wall_seconds: float
+    observations_per_second: float
+    microseconds_per_observation: float
+    step_latency_ms: dict[str, float]
+    snapshot_bytes: int
+    peak_memory_mb: float
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a serialisable form of the benchmark."""
+        return {
+            "days": self.days,
+            "observations": self.observations,
+            "steps": self.steps,
+            "wall_seconds": self.wall_seconds,
+            "observations_per_second": self.observations_per_second,
+            "microseconds_per_observation": self.microseconds_per_observation,
+            "step_latency_ms": self.step_latency_ms,
+            "snapshot_bytes": self.snapshot_bytes,
+            "peak_memory_mb": self.peak_memory_mb,
+        }
+
+
+def benchmark_pipeline(
+    days: int = 7,
+    *,
+    seed: int = 4242,
+    step: timedelta = timedelta(minutes=15),
+    trace_memory: bool = True,
+) -> PipelineBenchmark:
+    """Run the pipeline over a simulated household and measure it.
+
+    Latency is measured per *step* rather than per observation, because a
+    step is where the work happens: observations between steps only accumulate
+    in a buffer, while a step runs health, context, fusion and -- at a day
+    boundary -- the baselines and alerting.
+    """
+    result = simulate(HouseholdConfig(days=days, seed=seed))
+    pipeline = BehaviouralSensingPipeline(
+        result.registry, config=PipelineConfig(tz=result.config.tz, step=step)
+    )
+
+    if trace_memory:
+        tracemalloc.start()
+
+    latencies: list[float] = []
+    started = time.perf_counter()
+    latest = None
+    for observation in result.observations:
+        arrival = observation.received_at or observation.timestamp
+        pipeline.push(observation)
+        if latest is None or arrival > latest:
+            latest = arrival
+            before = time.perf_counter()
+            produced = pipeline.advance(arrival)
+            elapsed = time.perf_counter() - before
+            if produced:
+                latencies.extend([elapsed / len(produced)] * len(produced))
+    pipeline.close(result.end)
+    wall = time.perf_counter() - started
+
+    peak_mb = 0.0
+    if trace_memory:
+        peak_mb = tracemalloc.get_traced_memory()[1] / 1_000_000
+        tracemalloc.stop()
+
+    snapshot = json.dumps(pipeline.snapshot(), default=str)
+    count = len(result.observations)
+    samples = np.array(latencies) * 1000.0 if latencies else np.zeros(1)
+
+    return PipelineBenchmark(
+        days=days,
+        observations=count,
+        steps=len(latencies),
+        wall_seconds=wall,
+        observations_per_second=count / wall if wall > 0 else 0.0,
+        microseconds_per_observation=(wall / count * 1e6) if count else 0.0,
+        step_latency_ms={
+            "mean": float(samples.mean()),
+            "median": float(np.median(samples)),
+            "p95": float(np.percentile(samples, 95)),
+            "max": float(samples.max()),
+        },
+        snapshot_bytes=len(snapshot.encode("utf-8")),
+        peak_memory_mb=peak_mb,
+    )
+
+
+@dataclass(frozen=True)
+class BoundedStateResult:
+    """Evidence for or against the bounded-memory claim."""
+
+    short_days: int
+    long_days: int
+    short_snapshot_bytes: int
+    long_snapshot_bytes: int
+
+    @property
+    def growth_ratio(self) -> float:
+        """How much retained state grew for a much longer run.
+
+        A bounded pipeline stays near one. A value tracking the ratio of the
+        run lengths would mean state is accumulating with the stream.
+        """
+        if self.short_snapshot_bytes == 0:
+            return float("inf")
+        return self.long_snapshot_bytes / self.short_snapshot_bytes
+
+    @property
+    def workload_ratio(self) -> float:
+        """How much longer the long run was."""
+        return self.long_days / self.short_days if self.short_days else float("inf")
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a serialisable form of the result."""
+        return {
+            "short_days": self.short_days,
+            "long_days": self.long_days,
+            "short_snapshot_bytes": self.short_snapshot_bytes,
+            "long_snapshot_bytes": self.long_snapshot_bytes,
+            "growth_ratio": self.growth_ratio,
+            "workload_ratio": self.workload_ratio,
+        }
+
+
+def measure_bounded_state(
+    short_days: int = 3,
+    long_days: int = 21,
+    *,
+    seed: int = 4242,
+    step: timedelta = timedelta(minutes=30),
+    baseline_config: BaselineConfig | None = None,
+) -> BoundedStateResult:
+    """Compare retained state after a short run against a much longer one.
+
+    This is the direct test of the bounded-memory claim. Every stage but the
+    baselines keeps a fixed-size belief, and the baselines keep a history
+    capped at ``history_days``.
+
+    That cap is why the growth ratio is not exactly one by default: over a few
+    weeks the history is still filling, so a longer run legitimately retains
+    more. Pass a *baseline_config* whose ``history_days`` both runs exceed to
+    observe the asymptotic behaviour, where retained state stops growing
+    however long the pipeline runs.
+    """
+    if short_days >= long_days:
+        raise ValueError("long_days must exceed short_days")
+
+    sizes: dict[int, int] = {}
+    for days in (short_days, long_days):
+        result = simulate(HouseholdConfig(days=days, seed=seed))
+        pipeline = BehaviouralSensingPipeline(
+            result.registry,
+            config=PipelineConfig(tz=result.config.tz, step=step),
+            baseline_config=baseline_config,
+        )
+        pipeline.run(result.observations)
+        pipeline.close(result.end)
+        sizes[days] = len(json.dumps(pipeline.snapshot(), default=str).encode("utf-8"))
+
+    outcome = BoundedStateResult(
+        short_days=short_days,
+        long_days=long_days,
+        short_snapshot_bytes=sizes[short_days],
+        long_snapshot_bytes=sizes[long_days],
+    )
+    logger.info(
+        "State grew %.2fx for a %.1fx longer run",
+        outcome.growth_ratio,
+        outcome.workload_ratio,
+    )
+    return outcome
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    logging.basicConfig(level=logging.INFO)
+    print(json.dumps(benchmark_pipeline().to_dict(), indent=2))
+    print(json.dumps(measure_bounded_state().to_dict(), indent=2))

--- a/tests/performance/test_online_benchmarks.py
+++ b/tests/performance/test_online_benchmarks.py
@@ -1,0 +1,89 @@
+"""Performance and bounded-memory checks for the online pipeline.
+
+Thresholds here are deliberately loose. They exist to catch a regression that
+changes behaviour by an order of magnitude, not to pin down performance on a
+particular machine, and CI runners vary far too much for tight bounds to mean
+anything.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from sensor_modeling.baseline import BaselineConfig
+from sensor_modeling.online import benchmark_pipeline, measure_bounded_state
+
+
+class TestThroughput:
+    def test_the_pipeline_processes_a_week_in_reasonable_time(self) -> None:
+        result = benchmark_pipeline(days=3, step=timedelta(minutes=30))
+        assert result.observations > 1000
+        assert result.steps > 50
+        assert result.wall_seconds < 120
+
+    def test_per_observation_cost_stays_in_microseconds(self) -> None:
+        result = benchmark_pipeline(days=3, step=timedelta(minutes=30))
+        assert result.microseconds_per_observation < 2000
+
+    def test_step_latency_is_reported_across_percentiles(self) -> None:
+        result = benchmark_pipeline(days=3, step=timedelta(minutes=30))
+        latency = result.step_latency_ms
+        assert latency["median"] <= latency["p95"] <= latency["max"]
+        assert latency["p95"] < 500
+
+    def test_a_benchmark_serialises(self) -> None:
+        payload = benchmark_pipeline(days=2, step=timedelta(hours=1)).to_dict()
+        assert set(payload) >= {
+            "observations",
+            "steps",
+            "observations_per_second",
+            "step_latency_ms",
+            "snapshot_bytes",
+        }
+
+    def test_memory_tracing_can_be_disabled(self) -> None:
+        result = benchmark_pipeline(days=2, step=timedelta(hours=1), trace_memory=False)
+        assert result.peak_memory_mb == 0.0
+
+
+class TestBoundedState:
+    def test_retained_state_is_small_enough_for_a_constrained_device(self) -> None:
+        result = benchmark_pipeline(days=3, step=timedelta(minutes=30))
+        assert result.snapshot_bytes < 200_000
+
+    def test_state_grows_far_more_slowly_than_the_workload(self) -> None:
+        result = measure_bounded_state(
+            short_days=3, long_days=15, step=timedelta(hours=1)
+        )
+        assert result.workload_ratio == pytest.approx(5.0)
+        # Sub-linear by a wide margin: a five-fold longer run must not retain
+        # anything like five times as much.
+        assert result.growth_ratio < 2.0
+
+    def test_state_stops_growing_once_the_history_cap_is_reached(self) -> None:
+        """The asymptotic property that makes indefinite operation possible.
+
+        Below the cap the baseline history is still filling, so some growth is
+        legitimate. Once both runs exceed it, retained state must be flat
+        however long the pipeline has been running.
+        """
+        result = measure_bounded_state(
+            short_days=12,
+            long_days=36,
+            step=timedelta(hours=1),
+            baseline_config=BaselineConfig(history_days=7, min_samples=3),
+        )
+        assert result.growth_ratio < 1.1
+
+    def test_the_comparison_requires_a_longer_second_run(self) -> None:
+        with pytest.raises(ValueError, match="must exceed"):
+            measure_bounded_state(short_days=10, long_days=5)
+
+    def test_a_bounded_state_result_serialises(self) -> None:
+        payload = measure_bounded_state(
+            short_days=2, long_days=5, step=timedelta(hours=1)
+        ).to_dict()
+        assert payload["workload_ratio"] == pytest.approx(2.5)
+        assert payload["growth_ratio"] > 0


### PR DESCRIPTION
Measures throughput, per-step latency percentiles, snapshot size and peak allocation, plus a direct check of the bounded-memory claim by comparing retained state after a short run against a much longer one.

Once both runs exceed the baseline history cap, state grows 1.01x for a 3x longer run. Thresholds in the tests are loose, to catch regressions rather than pin performance to a machine.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds benchmark utilities for the online pipeline that measure throughput, per-step latency percentiles, snapshot size, and peak allocation, and exports them from `sensor_modeling.online`.

**New Features**
- Retained state is verified by comparing snapshots after short and long runs; once both exceed the baseline history cap, a 3x longer run grows state only 1.01x.
- Performance tests use loose thresholds to catch order-of-magnitude regressions rather than machine-specific numbers.

<sup>Written for commit f2da44fa5df470a5d8dafbf6376aebd322713e6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/67?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

