### PR TITLE
Add pseudonymisation and export redaction

### DIFF
--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -373,3 +373,49 @@ reasonably fill the gaps with zeros.
    server, and its codes come from a project-local code system rather than
    LOINC or SNOMED. Its output must not be presented as clinically validated
    data.
+
+Privacy helpers for export
+--------------------------
+
+:mod:`sensor_modeling.interop.privacy` provides pseudonymisation and redaction
+for data leaving a research environment. Two things it deliberately does not
+claim:
+
+**Pseudonymisation is not anonymisation.** Replacing an identifier removes the
+name, not the person. A behavioural record is a detailed account of when
+somebody sleeps, eats and leaves the house, and anyone with a little side
+information can often re-identify it. Pseudonymised exports remain personal
+data. Bundles are tagged to say so.
+
+**A hash is not a pseudonym.** Hashing a short identifier such as
+``patient_7`` protects nothing, because an attacker hashes every plausible
+identifier and matches. Pseudonyms are therefore keyed with a secret salt of
+at least sixteen characters, which must be supplied and kept separately from
+the data.
+
+Pseudonyms are deterministic across runs and machines, so a longitudinal study
+can link a subject's records without holding their identity, and are scoped by
+study, so the same person carries different identifiers in different studies
+and records cannot be joined across them.
+
+.. code-block:: python
+
+    from sensor_modeling.interop import identifiers_in, redact_bundle
+
+    # See what would leave before it leaves.
+    identifiers_in(exported)
+
+    safe = redact_bundle(
+        exported,
+        salt=study_salt,
+        subjects=["Patient/mrs-silva"],
+        sensors=["kitchen_motion"],
+    )
+
+Redaction strips free-form metadata and scrubs anything resembling contact
+details from remaining text, while preserving the measurements, their
+timestamps and their provenance -- a reader of a redacted bundle can still
+tell a measurement from an inference. Where a pseudonym is supplied, the field
+carrying the identifier is kept and its value replaced rather than dropped;
+dropping it would be stronger but would destroy the ability to link records at
+all, which is the point of pseudonymising rather than deleting.

--- a/sensor_modeling/interop/__init__.py
+++ b/sensor_modeling/interop/__init__.py
@@ -23,17 +23,35 @@ from .fhir import (
     state_resource,
     summarise_provenance,
 )
+from .privacy import (
+    DEFAULT_REDACTED_KEYS,
+    Pseudonymiser,
+    RedactionPolicy,
+    SaltError,
+    identifiers_in,
+    redact,
+    redact_bundle,
+    research_identifier,
+)
 
 __all__ = [
     "CODE_SYSTEM",
+    "DEFAULT_REDACTED_KEYS",
     "PROVENANCE_DERIVED_FEATURE",
     "PROVENANCE_INFERRED",
     "PROVENANCE_MEASURED",
     "RESEARCH_NOTE",
+    "Pseudonymiser",
+    "RedactionPolicy",
+    "SaltError",
     "alert_resource",
     "bundle",
+    "identifiers_in",
     "measured_only",
     "observation_resource",
+    "redact",
+    "redact_bundle",
+    "research_identifier",
     "state_resource",
     "summarise_provenance",
 ]

--- a/sensor_modeling/interop/privacy.py
+++ b/sensor_modeling/interop/privacy.py
@@ -1,0 +1,282 @@
+"""Pseudonymisation and redaction for exported research data.
+
+Two claims this module does **not** make, stated first because getting them
+wrong is how re-identification happens:
+
+*Pseudonymisation is not anonymisation.* Replacing an identifier with a
+pseudonym removes the name, not the person. A behavioural record is a detailed
+account of when somebody sleeps, eats and leaves the house; anyone with a
+little side information can often re-identify it. Pseudonymised exports remain
+personal data and must be handled as such.
+
+*A hash is not a pseudonym.* Hashing a short identifier such as ``patient_7``
+protects nothing: an attacker hashes every plausible identifier and matches.
+Pseudonyms here are therefore keyed with a secret salt, so the mapping cannot
+be reconstructed without it. The salt must be supplied, never defaulted, and
+must be kept separately from the data it protects.
+
+What the module does provide: deterministic pseudonyms that are stable across
+runs and machines, so a longitudinal study can link a subject's records
+without holding their identity; and a redaction pass that strips the
+free-form metadata an export does not need.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import re
+from collections.abc import Iterable, Mapping, MutableMapping
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Fields whose values are free-form and most likely to carry incidental
+#: identifiers -- a room named after a person, an installer's note, a device
+#: label containing a street address.
+DEFAULT_REDACTED_KEYS: frozenset[str] = frozenset(
+    {"context", "note", "notes", "detail", "description", "display", "text"}
+)
+
+#: Patterns that look like contact details or locations wherever they appear.
+_EMAIL = re.compile(r"[\w.+-]+@[\w-]+\.[\w.]+")
+_PHONE = re.compile(r"(?<!\d)(?:\+\d{1,3}[\s-]?)?(?:\d[\s-]?){9,14}\d(?!\d)")
+_POSTCODE = re.compile(r"\b[A-Z]{1,2}\d[A-Z\d]?\s*\d[A-Z]{2}\b", re.IGNORECASE)
+
+REDACTED = "[redacted]"
+
+
+class SaltError(ValueError):
+    """Raised when a pseudonymisation salt is missing or too weak."""
+
+
+@dataclass
+class Pseudonymiser:
+    """Deterministic, keyed pseudonyms for identifiers.
+
+    Parameters
+    ----------
+    salt
+        Secret key. Must be at least 16 characters. Keep it separately from
+        the exported data: together, they reverse the pseudonymisation for
+        anyone who can enumerate candidate identifiers.
+    prefix
+        Prepended to each pseudonym so its kind stays legible.
+    length
+        Hexadecimal characters retained. The default gives a collision
+        probability far below one in a billion for study-sized cohorts while
+        staying short enough to read.
+
+    Notes
+    -----
+    The same identifier and salt always produce the same pseudonym, on any
+    machine and in any process, which is what lets a longitudinal study link
+    records without holding identities.
+    """
+
+    salt: str
+    prefix: str = "subj"
+    length: int = 16
+
+    def __post_init__(self) -> None:
+        """Reject a salt too weak to be worth having."""
+        if not isinstance(self.salt, str) or len(self.salt) < 16:
+            raise SaltError(
+                "salt must be at least 16 characters; a short or guessable "
+                "salt lets an attacker reconstruct the mapping by enumerating "
+                "candidate identifiers"
+            )
+        if not 8 <= self.length <= 64:
+            raise ValueError("length must lie between 8 and 64 characters")
+
+    def pseudonym(self, identifier: str) -> str:
+        """Return the stable pseudonym for *identifier*."""
+        if not isinstance(identifier, str) or not identifier.strip():
+            raise ValueError("identifier must be a non-empty string")
+        digest = hmac.new(
+            self.salt.encode("utf-8"), identifier.encode("utf-8"), hashlib.sha256
+        ).hexdigest()
+        return f"{self.prefix}-{digest[: self.length]}"
+
+    def mapping(self, identifiers: Iterable[str]) -> dict[str, str]:
+        """Return the pseudonym for each identifier.
+
+        The result is the re-identification key. Store it separately from the
+        exported data, or not at all.
+        """
+        return {identifier: self.pseudonym(identifier) for identifier in identifiers}
+
+
+def research_identifier(study: str, subject: str, *, salt: str) -> str:
+    """Return a reproducible identifier for a subject within a study.
+
+    Scoping by study means the same person carries different identifiers in
+    different studies, so records cannot be joined across them by identifier
+    alone.
+    """
+    return Pseudonymiser(salt=salt, prefix=f"{study}").pseudonym(subject)
+
+
+@dataclass
+class RedactionPolicy:
+    """What an export should strip before leaving the research environment.
+
+    Parameters
+    ----------
+    drop_keys
+        Keys removed entirely wherever they appear.
+    scrub_patterns
+        Whether to replace anything resembling an email address, telephone
+        number or postcode in remaining free text.
+    keep_keys
+        Keys preserved even if they appear in *drop_keys*. Use sparingly and
+        deliberately.
+    """
+
+    drop_keys: frozenset[str] = field(default=DEFAULT_REDACTED_KEYS)
+    scrub_patterns: bool = True
+    keep_keys: frozenset[str] = field(default_factory=frozenset)
+
+    def should_drop(self, key: str) -> bool:
+        """Whether a key is removed under this policy."""
+        return key in self.drop_keys and key not in self.keep_keys
+
+
+def _scrub(text: str) -> str:
+    """Replace contact details and locations in free text."""
+    scrubbed = _EMAIL.sub(REDACTED, text)
+    scrubbed = _PHONE.sub(REDACTED, scrubbed)
+    return _POSTCODE.sub(REDACTED, scrubbed)
+
+
+def redact(
+    payload: Any,
+    policy: RedactionPolicy | None = None,
+    *,
+    pseudonyms: Mapping[str, str] | None = None,
+) -> Any:
+    """Return a copy of *payload* with identifying material removed.
+
+    Walks any nested structure of mappings and sequences, so it applies
+    equally to a single resource, a bundle, or a whole experiment record.
+
+    Parameters
+    ----------
+    payload
+        The structure to redact. Not modified.
+    policy
+        What to strip. Defaults to removing free-form metadata and scrubbing
+        contact details from remaining text.
+    pseudonyms
+        Replacements applied to any string that exactly matches a key. Use
+        :meth:`Pseudonymiser.mapping` to build it.
+    """
+    rules = policy or RedactionPolicy()
+    replacements = pseudonyms or {}
+
+    if isinstance(payload, Mapping):
+        result: MutableMapping[str, Any] = {}
+        for key, value in payload.items():
+            name = str(key)
+            if rules.should_drop(name):
+                continue
+            result[name] = redact(value, rules, pseudonyms=replacements)
+        return result
+
+    if isinstance(payload, (list, tuple)):
+        return [redact(item, rules, pseudonyms=replacements) for item in payload]
+
+    if isinstance(payload, str):
+        if payload in replacements:
+            return replacements[payload]
+        return _scrub(payload) if rules.scrub_patterns else payload
+
+    return payload
+
+
+def redact_bundle(
+    bundle: Mapping[str, Any],
+    *,
+    salt: str,
+    subjects: Iterable[str] = (),
+    sensors: Iterable[str] = (),
+    policy: RedactionPolicy | None = None,
+) -> dict[str, Any]:
+    """Pseudonymise and redact an exported bundle in one pass.
+
+    Subjects and sensors are pseudonymised under separate prefixes, so a
+    reader can still tell which kind of identifier they are looking at
+    without being able to recover either.
+
+    Where a pseudonym is supplied, the field carrying the identifier is
+    *kept* and its value replaced, rather than dropped. Dropping it would be
+    stronger, but it would also destroy the ability to link a record to its
+    sensor or subject, which is the whole point of pseudonymising rather
+    than deleting.
+    """
+    subject_names = list(subjects)
+    sensor_names = list(sensors)
+    replacements: dict[str, str] = {}
+    if subject_names:
+        replacements.update(
+            Pseudonymiser(salt=salt, prefix="subj").mapping(subject_names)
+        )
+    if sensor_names:
+        replacements.update(
+            Pseudonymiser(salt=salt, prefix="sens").mapping(sensor_names)
+        )
+
+    # Keep the fields the pseudonyms are meant to land in. Without this the
+    # default policy would drop `display` outright and the sensor pseudonyms
+    # would have nowhere to go.
+    rules = policy or RedactionPolicy()
+    if replacements:
+        rules = RedactionPolicy(
+            drop_keys=rules.drop_keys,
+            scrub_patterns=rules.scrub_patterns,
+            keep_keys=rules.keep_keys | frozenset({"display", "reference"}),
+        )
+
+    redacted = redact(bundle, rules, pseudonyms=replacements)
+    if not isinstance(redacted, dict):  # pragma: no cover - bundles are mappings
+        raise TypeError("a bundle must be a mapping")
+
+    meta = redacted.setdefault("meta", {})
+    tags = meta.setdefault("tag", [])
+    tags.append(
+        {
+            "code": "pseudonymised",
+            "display": (
+                "Identifiers replaced with keyed pseudonyms and free-form "
+                "metadata removed. Pseudonymised behavioural data remains "
+                "personal data: it is not anonymised and can often be "
+                "re-identified from side information."
+            ),
+        }
+    )
+    logger.info("Redacted bundle: %d identifiers pseudonymised", len(replacements))
+    return redacted
+
+
+def identifiers_in(bundle: Mapping[str, Any]) -> set[str]:
+    """Collect the sensor and subject identifiers a bundle carries.
+
+    Provided so a caller can see what would be pseudonymised before doing it,
+    rather than discovering an unredacted identifier after export.
+    """
+    found: set[str] = set()
+
+    def walk(node: Any) -> None:
+        if isinstance(node, Mapping):
+            for key, value in node.items():
+                if key in {"display", "reference"} and isinstance(value, str):
+                    found.add(value)
+                walk(value)
+        elif isinstance(node, (list, tuple)):
+            for item in node:
+                walk(item)
+
+    walk(bundle)
+    return found

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -1,0 +1,203 @@
+"""Tests for pseudonymisation and export redaction."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from sensor_modeling.interop import (
+    Pseudonymiser,
+    RedactionPolicy,
+    SaltError,
+    bundle,
+    identifiers_in,
+    redact,
+    redact_bundle,
+    research_identifier,
+)
+from sensor_modeling.observations import Modality, Observation, ObservationKind
+
+SALT = "a-long-enough-study-salt"
+T0 = datetime(2024, 5, 1, 8, 0, tzinfo=timezone.utc)
+
+
+def observation(**overrides: object) -> Observation:
+    """A measured activation with optional overrides."""
+    payload: dict[str, object] = {
+        "timestamp": T0,
+        "sensor_id": "kitchen_motion",
+        "modality": Modality.MOTION,
+        "kind": ObservationKind.EVENT,
+        "value": 1.0,
+    }
+    payload.update(overrides)
+    return Observation(**payload)  # type: ignore[arg-type]
+
+
+class TestPseudonyms:
+    def test_the_same_identifier_always_maps_to_the_same_pseudonym(self) -> None:
+        """Stability across runs is what lets a study link records."""
+        first = Pseudonymiser(salt=SALT).pseudonym("patient_7")
+        second = Pseudonymiser(salt=SALT).pseudonym("patient_7")
+        assert first == second
+
+    def test_different_identifiers_map_differently(self) -> None:
+        maker = Pseudonymiser(salt=SALT)
+        assert maker.pseudonym("patient_7") != maker.pseudonym("patient_8")
+
+    def test_a_different_salt_gives_a_different_pseudonym(self) -> None:
+        """Without the salt the mapping cannot be reconstructed."""
+        assert Pseudonymiser(salt=SALT).pseudonym("patient_7") != Pseudonymiser(
+            salt="an-entirely-different-salt"
+        ).pseudonym("patient_7")
+
+    def test_a_pseudonym_does_not_contain_the_identifier(self) -> None:
+        assert "patient_7" not in Pseudonymiser(salt=SALT).pseudonym("patient_7")
+
+    def test_a_bare_hash_of_the_identifier_does_not_match(self) -> None:
+        """Guards the keying: an unsalted digest would be trivially reversed."""
+        import hashlib
+
+        bare = hashlib.sha256(b"patient_7").hexdigest()
+        assert bare[:16] not in Pseudonymiser(salt=SALT).pseudonym("patient_7")
+
+    def test_a_short_salt_is_refused(self) -> None:
+        with pytest.raises(SaltError, match="at least 16 characters"):
+            Pseudonymiser(salt="short")
+
+    def test_an_empty_identifier_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            Pseudonymiser(salt=SALT).pseudonym("  ")
+
+    def test_an_implausible_length_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="length"):
+            Pseudonymiser(salt=SALT, length=4)
+
+    def test_a_mapping_covers_every_identifier(self) -> None:
+        mapping = Pseudonymiser(salt=SALT).mapping(["a", "b", "c"])
+        assert set(mapping) == {"a", "b", "c"}
+        assert len(set(mapping.values())) == 3
+
+    def test_study_scoping_prevents_joining_across_studies(self) -> None:
+        """The same person must not be linkable between two studies."""
+        first = research_identifier("sleepstudy", "patient_7", salt=SALT)
+        second = research_identifier("mobilitystudy", "patient_7", salt=SALT)
+        assert first != second
+        assert first.startswith("sleepstudy-")
+
+
+class TestRedaction:
+    def test_free_form_metadata_is_removed(self) -> None:
+        payload = {"value": 1.0, "context": {"installer": "Ana"}, "note": "private"}
+        assert redact(payload) == {"value": 1.0}
+
+    def test_contact_details_are_scrubbed_from_remaining_text(self) -> None:
+        payload = {"summary": "contact ana@example.com or +351 912 345 678"}
+        cleaned = redact(payload)
+        assert "ana@example.com" not in cleaned["summary"]
+        assert "912" not in cleaned["summary"]
+
+    def test_scrubbing_can_be_disabled(self) -> None:
+        policy = RedactionPolicy(scrub_patterns=False, drop_keys=frozenset())
+        payload = {"summary": "ana@example.com"}
+        assert redact(payload, policy)["summary"] == "ana@example.com"
+
+    def test_a_key_can_be_kept_deliberately(self) -> None:
+        policy = RedactionPolicy(keep_keys=frozenset({"description"}))
+        payload = {"description": "PIR in the kitchen", "note": "gone"}
+        cleaned = redact(payload, policy)
+        assert "description" in cleaned
+        assert "note" not in cleaned
+
+    def test_nested_structures_are_walked(self) -> None:
+        payload = {"entry": [{"resource": {"note": "x", "value": 2}}]}
+        assert redact(payload) == {"entry": [{"resource": {"value": 2}}]}
+
+    def test_the_input_is_not_modified(self) -> None:
+        payload = {"note": "private", "value": 1}
+        redact(payload)
+        assert "note" in payload
+
+    def test_pseudonyms_replace_exact_matches(self) -> None:
+        cleaned = redact(
+            {"reference": "Patient/abc"},
+            pseudonyms={"Patient/abc": "subj-1234"},
+        )
+        assert cleaned["reference"] == "subj-1234"
+
+    def test_timestamps_are_not_mistaken_for_telephone_numbers(self) -> None:
+        payload = {"effectiveDateTime": "2024-05-01T08:00:00+00:00"}
+        assert redact(payload)["effectiveDateTime"] == "2024-05-01T08:00:00+00:00"
+
+    def test_numeric_values_are_untouched(self) -> None:
+        payload = {"value": 0.9123456789, "count": 42}
+        assert redact(payload) == payload
+
+
+class TestBundleRedaction:
+    @staticmethod
+    def exported() -> dict:
+        return bundle(
+            observations=[
+                observation(context={"installer": "call Ana on +351 912 345 678"})
+            ],
+            subject="Patient/mrs-silva",
+        )
+
+    def test_subject_and_sensor_are_pseudonymised(self) -> None:
+        safe = redact_bundle(
+            self.exported(),
+            salt=SALT,
+            subjects=["Patient/mrs-silva"],
+            sensors=["kitchen_motion"],
+        )
+        found = identifiers_in(safe)
+        assert "kitchen_motion" not in found
+        assert "Patient/mrs-silva" not in found
+        assert any(name.startswith("sens-") for name in found)
+
+    def test_a_pseudonymised_field_is_kept_rather_than_dropped(self) -> None:
+        """Dropping it would destroy the ability to link records at all."""
+        safe = redact_bundle(self.exported(), salt=SALT, sensors=["kitchen_motion"])
+        resource = safe["entry"][0]["resource"]
+        assert "device" in resource
+        assert resource["device"]["display"].startswith("sens-")
+
+    def test_incidental_metadata_is_removed(self) -> None:
+        safe = redact_bundle(self.exported(), salt=SALT)
+        assert "Ana" not in str(safe)
+        assert "912" not in str(safe)
+
+    def test_the_measurement_itself_survives(self) -> None:
+        """Redaction must not destroy the data the export exists to carry."""
+        safe = redact_bundle(self.exported(), salt=SALT, sensors=["kitchen_motion"])
+        resource = safe["entry"][0]["resource"]
+        assert resource["effectiveDateTime"] == T0.isoformat()
+        assert resource["valueQuantity"]["value"] == 1.0
+        assert resource["status"] == "final"
+
+    def test_provenance_survives_redaction(self) -> None:
+        """A reader must still be able to tell measurement from inference."""
+        safe = redact_bundle(self.exported(), salt=SALT)
+        resource = safe["entry"][0]["resource"]
+        assert any("provenance" in ext["url"] for ext in resource["extension"])
+
+    def test_the_bundle_is_tagged_as_pseudonymised_not_anonymised(self) -> None:
+        safe = redact_bundle(self.exported(), salt=SALT)
+        tag = safe["meta"]["tag"][-1]
+        assert tag["code"] == "pseudonymised"
+        assert "not anonymised" in tag["display"]
+
+    def test_redaction_is_reproducible(self) -> None:
+        first = redact_bundle(self.exported(), salt=SALT, sensors=["kitchen_motion"])
+        second = redact_bundle(self.exported(), salt=SALT, sensors=["kitchen_motion"])
+        assert first == second
+
+    def test_a_weak_salt_is_refused_at_the_bundle_level(self) -> None:
+        with pytest.raises(SaltError):
+            redact_bundle(self.exported(), salt="tiny", subjects=["a"])
+
+    def test_identifiers_can_be_inspected_before_export(self) -> None:
+        """So an unredacted identifier is found before it leaves, not after."""
+        assert "kitchen_motion" in identifiers_in(self.exported())


### PR DESCRIPTION
Salt-keyed pseudonyms that are stable across runs and scoped by study, so records link within a study but not across them. A short salt is refused, since an unsalted digest of a short identifier is trivially reversed.

Redaction strips free-form metadata and scrubs contact details while preserving measurements, timestamps and provenance. Bundles are tagged to record that pseudonymised behavioural data is not anonymised.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds salt-keyed pseudonymisation and redaction helpers for exported research data, so a study can link a subject's records across runs without exposing identifiers to the export's recipient.

- Pseudonyms are deterministic across runs and machines and scoped by study, so records link within a study but not across them.
- A salt is required and must be at least 16 characters; shorter salts are refused because an unsalted or short-salted digest of a short identifier is trivially reversed.
- Redaction drops free-form metadata keys and scrubs emails, phone numbers, and postcodes from remaining text while preserving measurements, timestamps, and provenance.
- When a pseudonym is supplied, the identifier field is kept with its value replaced rather than dropped, so record linking survives redaction.
- Redacted bundles are tagged `pseudonymised` to record that pseudonymised behavioural data is not anonymised.
- `identifiers_in` shows what would be pseudonymised before the export leaves, so an unredacted identifier is caught before transfer.

<sup>Written for commit 97d4a066315f1ba66f5ec04083998ec956a8fb61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/68?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

