### PR TITLE
Address redundant-sensor and under-delivery findings from review

### DIFF
--- a/docs/ADVERSARIAL_REVIEW.md
+++ b/docs/ADVERSARIAL_REVIEW.md
@@ -1,0 +1,248 @@
+# Adversarial Review
+
+A deliberate attempt to invalidate the platform, conducted as if the authors
+intended to publish research based on it. Findings are classified by how much
+they should stop that.
+
+| Severity | Meaning |
+| --- | --- |
+| **BLOCKING** | Would make a published result wrong. Must be fixed before use. |
+| **MAJOR** | Materially distorts results under conditions that will occur. |
+| **MINOR** | Real but bounded; worth knowing when interpreting output. |
+| **INFORMATIONAL** | Correct behaviour that looks like a defect, recorded so it is not "fixed" into a bug. |
+
+Findings marked *fixed* have a regression test named alongside them.
+
+---
+
+## BLOCKING
+
+**None outstanding.**
+
+Two findings were blocking when discovered during development and are fixed:
+
+### B1. A silent deployment was read as observed inactivity — *fixed*
+
+Event sensors make no promise to report, so the health monitor rightly refused
+to call their silence a failure. But when a gateway died and *every* sensor
+went quiet at once, the filter read the resulting silence as a genuinely
+inactive resident, at full confidence.
+
+Sensors declaring an `expected_interval` now act as canaries for the delivery
+path. When at least two of them, and enough of them, fall silent, event sensors
+silent over the same period are downgraded so their silence stops carrying
+evidential weight. Only *silence* counts as a canary signal; a stuck sensor is
+still delivering and says nothing about whether other records are arriving.
+
+Regression: `test_adversarial.py::test_a_total_outage_produces_abstention_not_confident_inactivity`
+
+### B2. A sleeping resident made the bed sensor look broken — *fixed*
+
+Stuck detection counted consecutive identical readings for every sensor kind.
+A bed sensor correctly reporting "occupied" through eight hours of sleep was
+therefore flagged `STUCK` and discounted to reliability 0.10 — removing the
+strongest evidence for sleep at exactly the moment it mattered.
+
+Consecutive identical readings now indicate a fault only for *sampled* sensors,
+which are supposed to track a varying quantity. A state sensor is judged stuck
+only once its level has persisted beyond any plausible real duration.
+
+Fixing this raised clean-record balanced accuracy from 0.805 to 0.858.
+
+Regression: `test_adversarial.py::test_a_night_of_bed_occupancy_is_not_a_stuck_sensor`
+
+---
+
+## MAJOR
+
+### M1. Redundant sensors drove the posterior to false certainty — *fixed*
+
+The filter combines sensors as conditionally independent given the state. Two
+sensors watching the same doorway are not independent, and nothing prevented
+their agreement being counted twice.
+
+Measured on identical copies of a single physical event, using deliberately
+weak evidence -- a rate of 2/hour for `kitchen_activity` against 1/hour
+elsewhere, and one activation -- so that the posterior was not already
+saturated and the compounding was visible:
+
+| Redundant copies | P(kitchen_activity) |
+| --- | --- |
+| 1 | 0.056 |
+| 2 | 0.098 |
+| 4 | 0.270 |
+| 8 | 0.809 |
+
+Eight views of one event turned a 5.6% belief into 81%. A deployment with
+overlapping coverage would have been systematically overconfident, and nothing
+in the output would have revealed it.
+
+`SensorSpec` now takes a `redundancy_group`, and `default_emissions` divides
+the evidence weight across the group. With the group declared, the posterior is
+identical (0.041) for one copy or eight.
+
+This does not solve correlation in general — two sensors can be strongly
+dependent without being redundant — but it addresses the case that actually
+occurs in deployments and makes the assumption visible at the point of
+declaration.
+
+Regression: `test_adversarial_fixes.py::TestRedundancy`
+
+### M2. Partial record loss biases inference toward inactivity — *partly fixed*
+
+The platform guards hard against a sensor that *stops* reporting. It did not
+guard against one that keeps reporting while dropping a share of its records,
+because the health monitor saw ongoing traffic and rated it healthy.
+
+This matters because the loss is rarely at random. A radio contended by
+movement, or a battery sagging under load, drops records precisely when the
+resident is active. Measured over eight simulated days:
+
+| Condition | Balanced accuracy | ECE | Recall(kitchen) | Recall(inactive) |
+| --- | --- | --- | --- | --- |
+| Complete | 0.748 | 0.136 | 0.705 | 0.850 |
+| 30% loss, at random | 0.680 | 0.133 | 0.639 | 0.912 |
+| 60% loss *while active* | 0.593 | 0.214 | **0.180** | **0.985** |
+
+Kitchen recall collapses to 0.18 while inactivity recall rises to 0.985: the
+system reports a quiet resident because the evidence of activity is what went
+missing. This is the exact conclusion the platform exists to avoid reaching by
+accident.
+
+**Fixed part.** A sensor that declared an `expected_interval` promised a
+cadence, so a sustained shortfall against it is detectable even when no
+individual gap is long. Delivering below `delivery_floor` (default 60%) of the
+promised rate is now `DEGRADED`, which discounts the sensor instead of
+weighting it as healthy.
+
+**Unfixed part.** For a purely event-driven sensor there is no promised rate,
+and a drop in activations is indistinguishable from the resident being less
+active — that is the same ambiguity that makes silence uninformative for those
+sensors. Detection there is not possible without redundancy or a heartbeat.
+
+Recommendation for deployments: give every sensor a heartbeat where the
+hardware allows it. It converts an undetectable bias into a detectable one.
+
+Regression: `test_adversarial_fixes.py::TestUnderDelivery`
+
+### M3. Occupancy and state layers share evidence — *open*
+
+Both consume the radar and beacon signals. They answer different questions, but
+their errors are consequently dependent: a radar fault degrades attribution and
+state inference together, and the reported uncertainty does not model that
+correlation.
+
+Not fixed. A correct treatment needs a joint or hierarchical formulation, which
+is a research change rather than a repair. Recorded in
+`docs/limitations.rst` and in the roadmap.
+
+---
+
+## MINOR
+
+### m1. Presence samples are correlated but combined as independent
+
+Successive radar or beacon readings mostly re-observe an unchanged situation.
+Treating them as independent drives the occupancy posterior to certainty within
+minutes. A `sample_weight` discount (default 0.2) is applied.
+
+The discount is chosen, not estimated. It is an inspectable correction rather
+than a claim of independence, and it is why occupancy posteriors are
+deliberately conservative.
+
+### m2. Filtering, not smoothing
+
+Daily features attribute each estimate's posterior to the interval *preceding*
+it. This lags slightly at transitions. A fixed-interval smoother would be more
+accurate; none is implemented, and no estimate is ever revised once emitted.
+
+### m3. Late records beyond tolerance are discarded
+
+Reordering succeeds within `lateness_tolerance`; anything later is counted in
+`pipeline.too_late` and dropped rather than replayed. A deployment with long
+uplink outages needs a replay strategy the pipeline does not provide.
+
+### m4. Pairing inflates standardised effect sizes
+
+Paired comparison removes between-household variance, which is correct, but it
+makes Cohen's *dz* large in a way an unpaired field study would not reproduce.
+Raw mean differences are reported alongside, and the caveat is stated where the
+ablation results are presented.
+
+### m5. Snapshots are unversioned
+
+State is checked against the current ontology and context set, so a mismatched
+snapshot is rejected with a clear error rather than misread. There is no schema
+version, so a future change to the state set invalidates stored snapshots
+rather than migrating them.
+
+---
+
+## INFORMATIONAL
+
+Behaviour that looks wrong at first inspection and is not. Recorded so it does
+not get "fixed" into a defect.
+
+### i1. Attribution is not exactly a no-op when the resident is alone
+
+Balanced accuracy is identical, but probabilities differ by order 1e-4. The
+occupancy model never becomes *certain* the resident is alone, and that
+residual uncertainty propagates. A model that reached certainty here would be
+overconfident.
+
+### i2. A sensor that never reported is `UNKNOWN`, not `MISSING`
+
+It may not be installed. Only a sensor that stops after establishing a cadence
+can be judged missing.
+
+### i3. Abstentions count as errors
+
+`UNKNOWN` is never a true label, so a reported `UNKNOWN` is scored wrong. This
+makes the conservative system look worse on raw accuracy, which is why
+`selective_accuracy` and `abstention_rate` are always reported beside it.
+
+### i4. A detected change produces follow-on alerts
+
+After a real change is reported, the trend detector keeps firing on the same
+sustained shift, so the changed arm shows a higher unmatched-alert rate than
+the stable arm (0.033 against 0.010 per person-day). Deduplication bounds it,
+but a genuine change does cost more than one alert.
+
+### i5. Spring-forward duplicates are collapsed, not lost
+
+Two records whose local wall-clock times straddle a DST gap can resolve to the
+same absolute instant. If they share a sensor and value they are indistinguishable
+and are collapsed. Advancing time in UTC avoids constructing them.
+
+---
+
+## Areas probed with no finding
+
+Checked deliberately, nothing to report:
+
+- **Probability integrity.** Every belief remains finite, non-negative and
+  normalised under combined loss, duplication, lateness and clock drift.
+- **Time handling.** DST transitions in both directions, reordered events,
+  duplicate timestamps, late arrival, per-source clock drift.
+- **Missingness sweep.** 5/10/20/40% loss degrades accuracy smoothly with
+  bounded calibration error and no cliff.
+- **Alert storms.** A wholly broken deployment produces fewer than 15 alerts
+  over ten days and no behavioural findings at all.
+- **Circular validation.** Guard tests assert the simulator does not import the
+  inference transition model, and the pipeline does not import ground truth.
+- **Unpaired comparison.** `AblationReport.series()` refuses to return a series
+  when a configuration is missing a seed.
+- **Calibration metric.** Expected calibration error rises with overconfidence
+  and falls with honest uncertainty on constructed cases.
+- **Public API.** No symbol was removed or changed; the original models, CLI
+  subcommands and `SensorDataset` behave as before.
+
+---
+
+## Standing recommendation
+
+Every finding above was found against a simulator. The most likely place for an
+undiscovered BLOCKING defect is the gap between that simulator and a real home,
+and no amount of adversarial testing inside the simulator will close it.
+Validation against a public annotated dataset remains the highest-value next
+step.

--- a/sensor_modeling/fusion/defaults.py
+++ b/sensor_modeling/fusion/defaults.py
@@ -258,17 +258,37 @@ def default_emission_for(
     return None
 
 
+def _group_sizes(registry: SensorRegistry) -> dict[str, int]:
+    """Count how many sensors share each declared redundancy group."""
+    sizes: dict[str, int] = {}
+    for spec in registry:
+        if spec.redundancy_group:
+            sizes[spec.redundancy_group] = sizes.get(spec.redundancy_group, 0) + 1
+    return sizes
+
+
 def default_emissions(
     registry: SensorRegistry,
     ontology: StateOntology,
     defaults: EmissionDefaults | None = None,
 ) -> list[EmissionModel]:
-    """Build default observation models for every sensor that has one."""
-    models = [
-        model
-        for spec in registry
-        if (model := default_emission_for(spec, ontology, defaults)) is not None
-    ]
+    """Build default observation models for every sensor that has one.
+
+    Sensors sharing a ``redundancy_group`` have their evidence weight divided
+    across the group. The filter combines sensors as conditionally
+    independent given the state, so without this, several views of the same
+    physical event accumulate as several independent observations and drive
+    the posterior toward certainty it has not earned.
+    """
+    sizes = _group_sizes(registry)
+    models: list[EmissionModel] = []
+    for spec in registry:
+        model = default_emission_for(spec, ontology, defaults)
+        if model is None:
+            continue
+        if spec.redundancy_group:
+            model.weight /= sizes[spec.redundancy_group]
+        models.append(model)
     if not models:
         raise ValueError(
             "no sensor in the registry carries information about behavioural state"

--- a/sensor_modeling/health/monitor.py
+++ b/sensor_modeling/health/monitor.py
@@ -169,6 +169,13 @@ class HealthConfig:
         Fraction of the sensors that *can* be checked for silence which must
         be failing before the silence of the sensors that cannot be checked
         is also distrusted. See :meth:`SensorHealthMonitor.report`.
+    delivery_floor
+        Fraction of its promised reporting rate a sensor must sustain before
+        it is called degraded. Catches a sensor that keeps reporting but
+        drops a share of its records -- no single gap is long enough to look
+        like a dropout, yet a large part of the evidence never arrives.
+    delivery_window
+        Inter-arrival samples retained for the delivery-rate estimate.
     """
 
     degraded_after: float = 2.0
@@ -184,6 +191,8 @@ class HealthConfig:
     drift_floor: float = 0.0
     out_of_range_tolerance: int = 2
     outage_canary_fraction: float = 0.6
+    delivery_floor: float = 0.6
+    delivery_window: int = 32
 
     def __post_init__(self) -> None:
         """Validate threshold configuration."""
@@ -210,6 +219,10 @@ class HealthConfig:
             raise ValueError("out_of_range_tolerance must be at least 1")
         if not 0.0 < self.outage_canary_fraction <= 1.0:
             raise ValueError("outage_canary_fraction must lie in (0, 1]")
+        if not 0.0 < self.delivery_floor <= 1.0:
+            raise ValueError("delivery_floor must lie in (0, 1]")
+        if self.delivery_window < 2:
+            raise ValueError("delivery_window must be at least 2")
 
 
 @dataclass
@@ -224,6 +237,7 @@ class _SensorState:
     repeats: int = 0
     repeat_since: datetime | None = None
     out_of_range_run: int = 0
+    intervals: deque[float] = field(default_factory=deque)
     reference: deque[float] = field(default_factory=deque)
     recent: deque[float] = field(default_factory=deque)
 
@@ -251,6 +265,7 @@ class SensorHealthMonitor:
                 quality=spec.prior_reliability,
                 reference=deque(maxlen=self.config.drift_reference),
                 recent=deque(maxlen=self.config.drift_recent),
+                intervals=deque(maxlen=self.config.delivery_window),
             )
             for spec in registry
         }
@@ -268,6 +283,10 @@ class SensorHealthMonitor:
 
         state.observations += 1
         if state.last_seen is None or observation.timestamp > state.last_seen:
+            if state.last_seen is not None:
+                gap = (observation.timestamp - state.last_seen).total_seconds()
+                if gap > 0:
+                    state.intervals.append(gap)
             state.last_seen = observation.timestamp
 
         smoothing = self.config.quality_smoothing
@@ -325,6 +344,39 @@ class SensorHealthMonitor:
             return SensorStatus.DEGRADED, f"silent for {elapsed:.1f} expected intervals"
         return None
 
+    def _under_delivering(self, state: _SensorState) -> tuple[SensorStatus, str] | None:
+        """Detect a sensor that keeps reporting but drops part of its record.
+
+        Silence-based checks look at the gap since the last observation, so a
+        sensor delivering only a fraction of its promised samples slips
+        through: every individual gap is short, yet most of the evidence
+        never arrives.
+
+        This matters more than it sounds. Losing records at random costs
+        accuracy roughly in proportion; losing them *when the resident is
+        active* -- a radio contended by movement, a battery sagging under
+        load -- biases inference toward inactivity, which is the exact
+        conclusion this platform must never reach by accident. Detecting the
+        shortfall does not repair the bias, but it stops the sensor being
+        weighted as though it were healthy.
+        """
+        interval = state.spec.expected_interval
+        if (
+            interval is None
+            or len(state.intervals) < max(state.intervals.maxlen or 2, 2) // 2
+        ):
+            return None
+        typical = statistics.median(state.intervals)
+        if typical <= 0:
+            return None
+        delivered = interval.total_seconds() / typical
+        if delivered >= self.config.delivery_floor:
+            return None
+        return (
+            SensorStatus.DEGRADED,
+            f"delivering about {delivered:.0%} of its promised reporting rate",
+        )
+
     def _drift(self, state: _SensorState) -> tuple[SensorStatus, str] | None:
         """Compare the recent calibration of a sampled sensor to its own past."""
         reference, recent = state.reference, state.recent
@@ -350,6 +402,9 @@ class SensorHealthMonitor:
                 SensorStatus.OUT_OF_RANGE,
                 f"{state.out_of_range_run} consecutive implausible readings",
             )
+        under = self._under_delivering(state)
+        if under is not None:
+            return under
         # Repeated identical readings mean different things per kind. An
         # event sensor reports the same value on every activation, and a
         # state sensor reports an unchanged level for as long as the level is
@@ -494,6 +549,7 @@ class SensorHealthMonitor:
                     state.repeat_since.isoformat() if state.repeat_since else None
                 ),
                 "out_of_range_run": state.out_of_range_run,
+                "intervals": list(state.intervals),
                 "reference": list(state.reference),
                 "recent": list(state.recent),
             }
@@ -520,6 +576,10 @@ class SensorHealthMonitor:
                 datetime.fromisoformat(str(repeat_since)) if repeat_since else None
             )
             state.out_of_range_run = int(payload.get("out_of_range_run", 0))
+            state.intervals = deque(
+                (float(v) for v in payload.get("intervals", ()) or ()),
+                maxlen=self.config.delivery_window,
+            )
             state.reference = deque(
                 (float(v) for v in payload.get("reference", ()) or ()),
                 maxlen=self.config.drift_reference,

--- a/sensor_modeling/observations/registry.py
+++ b/sensor_modeling/observations/registry.py
@@ -53,6 +53,13 @@ class SensorSpec:
     attributable
         Whether an activation identifies *who* generated it. True only for
         person-bound sensing such as a worn device or a personal beacon.
+    redundancy_group
+        Name shared by sensors observing substantially the same thing. The
+        fusion layer treats sensors as conditionally independent given the
+        state, so several views of one event would otherwise be counted as
+        several independent pieces of evidence and drive the posterior to
+        false certainty. Declaring a group divides the evidence weight
+        across it.
     description
         Human-readable note recording the precise semantics of the value.
     """
@@ -66,6 +73,7 @@ class SensorSpec:
     value_range: tuple[float, float] | None = None
     prior_reliability: float = 0.99
     attributable: bool = False
+    redundancy_group: str | None = None
     description: str = ""
 
     def __post_init__(self) -> None:
@@ -247,6 +255,7 @@ class SensorRegistry:
                 "value_range": list(spec.value_range) if spec.value_range else None,
                 "prior_reliability": spec.prior_reliability,
                 "attributable": spec.attributable,
+                "redundancy_group": spec.redundancy_group,
                 "description": spec.description,
             }
             for spec in self.specs.values()

--- a/tests/test_adversarial_fixes.py
+++ b/tests/test_adversarial_fixes.py
@@ -1,0 +1,216 @@
+"""Regression tests for defects found by adversarial review.
+
+Each test corresponds to a finding in ``docs/ADVERSARIAL_REVIEW.md`` and
+fails if that defect returns.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from sensor_modeling.fusion import MultimodalBayesFilter, default_emissions
+from sensor_modeling.health import HealthConfig, SensorHealthMonitor, SensorStatus
+from sensor_modeling.observations import (
+    Modality,
+    Observation,
+    ObservationKind,
+    SensorRegistry,
+    SensorSpec,
+)
+from sensor_modeling.states import BehaviouralState as S
+from sensor_modeling.states import StateOntology
+
+T0 = datetime(2024, 5, 1, 12, 0, tzinfo=timezone.utc)
+ONTOLOGY = StateOntology()
+
+
+def kitchen_registry(copies: int, *, group: str | None) -> SensorRegistry:
+    """A registry of *copies* sensors all watching the same kitchen."""
+    return SensorRegistry.from_specs(
+        [
+            SensorSpec(
+                f"kitchen_{index}",
+                Modality.MOTION,
+                room="kitchen",
+                redundancy_group=group,
+            )
+            for index in range(copies)
+        ]
+    )
+
+
+def belief_after_one_event(copies: int, *, group: str | None) -> float:
+    """Return P(kitchen_activity) after every copy reports one activation."""
+    registry = kitchen_registry(copies, group=group)
+    bayes = MultimodalBayesFilter(
+        ONTOLOGY, default_emissions(registry, ONTOLOGY), registry=registry
+    )
+    bayes.update(T0, [])
+    now = T0 + timedelta(minutes=5)
+    observations = [
+        Observation(
+            now - timedelta(seconds=10),
+            f"kitchen_{index}",
+            Modality.MOTION,
+            ObservationKind.EVENT,
+            1.0,
+        )
+        for index in range(copies)
+    ]
+    return bayes.update(now, observations).probabilities[S.KITCHEN_ACTIVITY]
+
+
+class TestRedundancy:
+    """M1: redundant sensors drove the posterior to false certainty."""
+
+    def test_undeclared_redundancy_still_compounds(self) -> None:
+        """Documents the hazard the declaration exists to prevent.
+
+        Without a declared group the filter has no way to know two sensors
+        watch the same thing, so the same evidence is applied once per copy.
+        The assertion is on how far the posterior moves, not on which way:
+        the compounding pushes toward or away from a state depending on
+        whether the observed count sits above or below what that state's
+        rate predicts, and it is wrong in either direction.
+        """
+        single = belief_after_one_event(1, group=None)
+        assert abs(belief_after_one_event(8, group=None) - single) > abs(
+            belief_after_one_event(2, group=None) - single
+        )
+
+    def test_a_declared_group_makes_copies_count_once(self) -> None:
+        single = belief_after_one_event(1, group="kitchen_pir")
+        for copies in (2, 4, 8):
+            assert belief_after_one_event(copies, group="kitchen_pir") == pytest.approx(
+                single, abs=1e-9
+            )
+
+    def test_grouping_removes_the_compounding_entirely(self) -> None:
+        """With the group declared, eight copies move the posterior no further
+        than one does."""
+        single = belief_after_one_event(1, group="kitchen_pir")
+        assert belief_after_one_event(8, group="kitchen_pir") == pytest.approx(
+            single, abs=1e-9
+        )
+
+    def test_the_group_is_recorded_in_the_registry_export(self) -> None:
+        exported = kitchen_registry(2, group="kitchen_pir").to_dict()
+        assert exported["kitchen_0"]["redundancy_group"] == "kitchen_pir"
+
+    def test_ungrouped_sensors_keep_their_full_weight(self) -> None:
+        registry = SensorRegistry.from_specs(
+            [SensorSpec("kitchen_0", Modality.MOTION, room="kitchen")]
+        )
+        emission = default_emissions(registry, ONTOLOGY)[0]
+        assert emission.weight == pytest.approx(1.0)
+
+
+class TestUnderDelivery:
+    """M2: a sensor dropping records still looked healthy."""
+
+    @staticmethod
+    def registry() -> SensorRegistry:
+        return SensorRegistry.from_specs(
+            [
+                SensorSpec(
+                    "hall_temp",
+                    Modality.ENVIRONMENTAL,
+                    kind=ObservationKind.SAMPLE,
+                    expected_interval=timedelta(minutes=1),
+                )
+            ]
+        )
+
+    @staticmethod
+    def verdict(spacing_seconds: int, *, config: HealthConfig | None = None) -> object:
+        """Report health immediately after a run at the given spacing.
+
+        Reporting one second after the latest observation keeps the silence
+        check from firing, so only the delivery-rate check can produce a
+        verdict.
+        """
+        monitor = SensorHealthMonitor(
+            TestUnderDelivery.registry(), config or HealthConfig(stuck_samples=999)
+        )
+        last = T0
+        for index in range(40):
+            last = T0 + timedelta(seconds=spacing_seconds * index)
+            monitor.observe(
+                Observation(
+                    last,
+                    "hall_temp",
+                    Modality.ENVIRONMENTAL,
+                    ObservationKind.SAMPLE,
+                    20.0 + (index % 5) * 0.1,
+                )
+            )
+        return monitor.report_for("hall_temp", last + timedelta(seconds=1))
+
+    def test_a_sensor_meeting_its_cadence_is_healthy(self) -> None:
+        assert self.verdict(60).status is SensorStatus.HEALTHY  # type: ignore[attr-defined]
+
+    def test_a_mild_shortfall_is_tolerated(self) -> None:
+        """67% of the promised rate sits above the default floor."""
+        assert self.verdict(90).status is SensorStatus.HEALTHY  # type: ignore[attr-defined]
+
+    def test_a_sensor_dropping_most_records_is_degraded(self) -> None:
+        report = self.verdict(150)
+        assert report.status is SensorStatus.DEGRADED  # type: ignore[attr-defined]
+        assert "promised reporting rate" in report.detail  # type: ignore[attr-defined]
+        assert report.reliability < 0.7  # type: ignore[attr-defined]
+
+    def test_the_shortfall_is_quantified_in_the_verdict(self) -> None:
+        assert "25%" in self.verdict(240).detail  # type: ignore[attr-defined]
+
+    def test_the_floor_is_configurable(self) -> None:
+        lenient = HealthConfig(stuck_samples=999, delivery_floor=0.2)
+        assert self.verdict(150, config=lenient).status is SensorStatus.HEALTHY  # type: ignore[attr-defined]
+
+    def test_an_event_sensor_without_a_cadence_is_not_judged(self) -> None:
+        """It never promised a rate, so a drop is indistinguishable from a
+        quieter resident."""
+        registry = SensorRegistry.from_specs(
+            [SensorSpec("fridge", Modality.CONTACT, room="kitchen")]
+        )
+        monitor = SensorHealthMonitor(registry)
+        for index in range(40):
+            monitor.observe(
+                Observation(
+                    T0 + timedelta(minutes=30 * index),
+                    "fridge",
+                    Modality.CONTACT,
+                    ObservationKind.EVENT,
+                    1.0,
+                )
+            )
+        report = monitor.report_for("fridge", T0 + timedelta(minutes=30 * 40))
+        assert not report.is_faulty
+
+    def test_invalid_delivery_configuration_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="delivery_floor"):
+            HealthConfig(delivery_floor=0.0)
+        with pytest.raises(ValueError, match="delivery_window"):
+            HealthConfig(delivery_window=1)
+
+    def test_delivery_history_survives_a_restart(self) -> None:
+        monitor = SensorHealthMonitor(self.registry(), HealthConfig(stuck_samples=999))
+        last = T0
+        for index in range(40):
+            last = T0 + timedelta(seconds=150 * index)
+            monitor.observe(
+                Observation(
+                    last,
+                    "hall_temp",
+                    Modality.ENVIRONMENTAL,
+                    ObservationKind.SAMPLE,
+                    20.0 + (index % 5) * 0.1,
+                )
+            )
+        restarted = SensorHealthMonitor(
+            self.registry(), HealthConfig(stuck_samples=999)
+        )
+        restarted.restore(monitor.snapshot())
+        report = restarted.report_for("hall_temp", last + timedelta(seconds=1))
+        assert report.status is SensorStatus.DEGRADED


### PR DESCRIPTION
Adversarial review found two major defects, both fixed with regression tests.

Redundant sensors were counted as independent evidence, so eight views of one event drove a 5.6% belief to 81%. SensorSpec now takes a redundancy group whose weight is divided across it.

A sensor dropping part of its record still looked healthy, which biases inference toward inactivity when loss correlates with activity. A sustained shortfall against a declared cadence is now degraded; for event sensors without a cadence it remains undetectable, and that is documented.

Review written up in docs/ADVERSARIAL_REVIEW.md.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two major defects found in the adversarial review — redundant sensors compounded into false certainty, and partial record loss went undetected — both with regression tests.

- `SensorSpec` now takes a `redundancy_group`; `default_emissions` divides the evidence weight across the group, so eight views of one event no longer push a 5.6% belief to 81%.
- The health monitor now marks a sensor `DEGRADED` when it sustains a shortfall against its declared `expected_interval` cadence, instead of rating it healthy on ongoing traffic.
- Under-delivery for event sensors without a cadence remains undetectable; that limitation is documented.
- Adds `docs/ADVERSARIAL_REVIEW.md` and `tests/test_adversarial_fixes.py` covering both fixes.

<sup>Written for commit 527229f65d314ed65bb4018d6297ca38b8c573d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

