### PR TITLE
Final integration review and release readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `sensor_modeling.online`: an incremental, bounded-memory, snapshot-able pipeline orchestrating the full chain with a lateness buffer for stream reordering.
 - Added `sensor-modeling demo` and `sensor-modeling ablate` commands, both reproducible from a fixed seed.
 - Added `sensor_modeling.interop`: a FHIR-style export that keeps measurements, derived features, inferred states and algorithmic alerts distinguishable, with explicit provenance on every resource, inferences marked `preliminary` with their full posterior and method, abstentions exported as `dataAbsentReason`, and alerts exported as `DetectedIssue` rather than `Observation`.
+- Added legacy adapters converting wide frames, datasets and long-format records into canonical observations, plus property-based tests for observation and stream invariants.
+- Added structured `Explanation` output alongside the one-line form, and calibration tests for state inference.
+- Added an attribution comparison measuring naive against occupancy-aware activity attribution across nine occupancy situations, with a `sensor-modeling attribution` command.
+- Added a change-detection study measuring delay against alert burden, and a ramped behaviour shift so gradual decline can be injected.
+- Added experiment provenance recording configuration, seeds, library versions and written metric definitions with every result.
+- Added online pipeline benchmarks for throughput, latency, snapshot size and bounded retained state.
+- Added pseudonymisation and export redaction with salt-keyed, study-scoped identifiers.
+- Added `sensor_modeling.observations.SensorSpec.redundancy_group` so correlated sensors are not counted as independent evidence.
+- Added detection of sensors that keep reporting while delivering below their declared cadence.
+- Added `docs/MULTIMODAL_ARCHITECTURE.md`, `docs/RESEARCH_QUESTIONS.md`, `docs/SENSOR_DATA_MODEL.md`, `docs/UNCERTAINTY_MODEL.md`, `docs/EVALUATION_DESIGN.md`, `docs/ADVERSARIAL_REVIEW.md`, `docs/RELEASE_READINESS.md` and `docs/multimodal_ingestion.rst`.
+- Added backwards-compatibility tests exercising the original models, data layer and public surface.
 - Added `docs/ambient_architecture.rst`, `docs/inference.rst`, `docs/evaluation.rst`, and `docs/limitations.rst`.
 - Added 327 tests covering the new packages, including DST transitions in both directions, out-of-order and duplicate delivery, sensor dropout, wearable non-adherence, visitor contamination, snapshot/restore, and end-to-end recovery against ground truth.
 - Added a top-level `ROADMAP.md` with release milestones, quality gates, longer-term priorities, maintenance backlog, and release policy.
@@ -59,6 +70,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated README and Sphinx roadmap documentation to point to the canonical roadmap.
 
 ### Fixed
+- Fixed the analysis pipeline defaulting to `NHPPConfig(n_basis=3)`, which violates the model's own `n_basis >= degree+1` constraint for the cubic default. Every NHPP fit raised and the pipeline recorded an error in place of a result, so that arm had never worked while appearing present in the output.
+- Fixed redundant sensors being counted as independent evidence, which drove the posterior toward certainty it had not earned.
+- Fixed a sensor delivering only part of its promised record being rated healthy, which biases inference toward inactivity when loss correlates with activity.
 - Fixed default emission rates conflating a state's location with its activity level, which made a bedroom motion sensor's silence argue against `sleeping` as hard as the bed sensor argued for it. End-to-end state accuracy rose from 0.585 to 0.918 and sleep recall from 0.00 to 0.96.
 - Fixed gradual drift being permanently unalertable: it has no deviation streak by construction, so grading it on magnitude and duration scored every slow decline at zero.
 - Fixed a drift's reported direction being read from the day rather than the trend, which allowed a verdict to announce a decrease while reporting a rising slope.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,34 @@ convention:
 The system can also return `unknown`. Abstention is a first-class output, not
 a failure.
 
+### Supported and unsupported claims
+
+The distinction the platform is built to hold. The left column is what the
+evidence supports; the right is what it does **not**, however tempting the
+inference.
+
+| Supported | Not supported |
+| --- | --- |
+| Evidence of kitchen activity | Food consumption |
+| Evidence of bathroom activity | Confirmed toileting |
+| Bed occupancy with sustained low movement | Clinically defined sleep, or a sleep disorder |
+| A door was crossed | The resident left the house |
+| A sustained change against the resident's own history | A cause, a prognosis, or a diagnosis |
+| Reduced room-to-room transitions | Deterioration in mobility as a clinical finding |
+| Sensor coverage has fallen | The resident has become less active |
+| `P(resident generated this activity) = 0.5` | Identification of who did it |
+
+Two of these deserve spelling out.
+
+**`kitchen_activity` is not eating.** A fridge contact records a door opening.
+Turning that into a meal requires evidence the sensor cannot supply, so the
+ontology stops where the evidence stops.
+
+**`sleeping` is not sleep.** It is bed occupancy accompanied by sustained low
+movement. It has no relationship to polysomnography, and mapping it to a
+clinical sleep concept is a further inferential step this platform does not
+take.
+
 ## 🏠 Multimodal ambient sensing pipeline
 
 ```text

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -1,0 +1,208 @@
+# Release Readiness Review
+
+Final integration review of the multimodal ambient-sensing work. Written for a
+human reviewer deciding whether the diff is ready for a version bump.
+
+**Recommendation: `0.2.0`.** The work is additive and backwards-compatible, so
+a minor bump is correct; the scope is far too large for a patch.
+
+Nothing has been merged to `main`, tagged, or published.
+
+---
+
+## 1. Implemented capabilities
+
+The pipeline runs end to end:
+
+```text
+heterogeneous sensors -> canonical observations -> sensor health
+    -> occupancy and attribution -> probabilistic behavioural state
+    -> adaptive baseline -> change detection -> explained alerts
+    -> evaluation and provenance-preserving export
+```
+
+| Package | Responsibility |
+| --- | --- |
+| `observations` | Canonical hardware-neutral model, registry, boundary validation, unit conversion, clock-drift correction, legacy adapters |
+| `health` | Online per-sensor reliability as an evidence weight |
+| `context` | Occupancy contexts and uncertainty-aware attribution |
+| `states` / `fusion` | Continuous-time ontology and recursive multimodal filter |
+| `baseline` | Adaptive, weekday-aware, non-stationary personal baselines |
+| `alerts` | Restrained alerting with deduplication and rate limiting |
+| `simulation` | Synthetic households with controlled ground truth |
+| `evaluation` | Metrics, paired ablation, attribution and detection studies, provenance |
+| `online` | Incremental orchestration, snapshotting, benchmarks |
+| `interop` | FHIR-style export, pseudonymisation, redaction |
+
+Four reproducible commands: `demo`, `ablate`, `attribution`, plus the original
+`bernoulli-ar` and `nhpp-pelt`.
+
+## 2. Quality gates
+
+| Gate | Status |
+| --- | --- |
+| Test suite | **654 passing**, 0 failing |
+| Coverage | 86% overall; 95% across the eleven new packages |
+| `mypy` (strict) | **0 errors in all new packages**; 168 pre-existing in 32 older files |
+| `ruff` | Clean |
+| `black` | Clean on every file touched |
+| `bandit` | No issues identified across 14,969 lines |
+| Sphinx | Builds with no warnings |
+| `python -m build` + `twine check` | Passing; all packages ship in the wheel |
+| Worked example | Runs from the command line, deterministic for a fixed seed |
+
+## 3. Backwards compatibility
+
+**No public symbol was removed or changed.** `tests/test_backwards_compatibility.py`
+exercises the original APIs in the way they were used before: Bernoulli AR,
+NHPP-PELT, the HMM variants, PELT, the lightweight change-point detectors, the
+analysis pipeline, behavioural metrics, `SensorDataset`, and the original CLI
+subcommands.
+
+A user of the previous release can upgrade and ignore the new packages
+entirely. `ObservationStream` bridges the two layers in both directions.
+
+**One pre-existing defect was fixed.** `AnalysisPipeline` defaulted to
+`NHPPConfig(n_basis=3)`, which violates the model's own `n_basis >= degree+1`
+constraint for the cubic default. Every fit raised, and the pipeline recorded
+`{"error": ...}` in place of a result — so the NHPP arm had never once worked,
+while appearing present in the output. Now `n_basis=4`, with a regression test.
+
+### One regression found by this review
+
+Wrapping experiment results in a provenance record nested the findings under
+`results`, which broke the CLI integration test asserting the old flat shape.
+It reached `develop` because that change was verified with targeted tests
+rather than the full suite. Fixed, with the attribution artefact now covered
+too.
+
+The lesson is procedural rather than technical: a change to an output *shape*
+needs the whole suite run, because the tests that break are rarely the ones
+near the change.
+
+## 4. Dependencies
+
+**No new dependencies were added.** Every one of the eleven new packages
+imports only `numpy`, `pandas` and `scipy`, all already declared as core
+requirements.
+
+One observation for the maintainer, not acted on: `pyproject.toml` declares an
+`ml` extra pulling `tensorflow`, `torch` and `transformers`. Nothing in the
+repository uses them, and the platform's stated position is that no neural
+component belongs on the inference path. Removing the extra would be a
+breaking change for anyone installing it, so it is flagged rather than changed.
+
+## 5. Evaluation results
+
+All figures come from the bundled simulator. See section 7.
+
+**State inference**, 90-day demonstration with visitors, a bed-sensor dropout,
+five days of wearable non-adherence, 3% loss, duplicates, late arrival and
+clock drift:
+
+| Metric | Value |
+| --- | --- |
+| Balanced accuracy | 0.824 |
+| Macro F1 | 0.806 |
+| Calibration error | 0.083 |
+| Recall (sleeping / away) | 0.954 / 0.959 |
+| Transition timing | 98.3% matched, median offset 0 min |
+
+**Robustness**, 0–40% record loss: balanced accuracy 0.858 → 0.748, calibration
+error 0.046 → 0.079. No cliff.
+
+**Sensor ablation**, four paired seeds: adding a wearable to six object sensors
+leaves a gap of 0.012 balanced accuracy against the full ten-sensor deployment
+(95% CI [+0.004, +0.020]) — real but small. A five-sensor configuration was the
+best calibrated of all despite lower accuracy.
+
+**Attribution**: no effect when nobody else is present, largest gain (+0.032)
+during a carer round.
+
+**Change detection**, three seeds: a step change detected at 5.0 days with
+0.010 false alerts per person-day on a stable record. Losing 30% of records did
+not raise the false-alert rate; detection delay rose to 7.7 days. Gradual
+change is harder — recall 0.67, delay 12.5 days.
+
+**Performance**: 19,345 observations/second, step latency p95 3.8 ms, snapshot
+6.5 KB. Once past the baseline history cap, retained state grows 1.01× for a 3×
+longer run.
+
+## 6. Scientific assumptions
+
+Stated so a reviewer can disagree with them:
+
+1. Sensors are conditionally independent given the state. Mitigated for the
+   redundant case by declared redundancy groups; not solved in general.
+2. State durations are exponentially distributed, as the Markov assumption
+   implies. Real dwell times are not.
+3. Successive presence samples are treated as independent and then discounted
+   by a chosen weight, rather than modelled as correlated.
+4. Emission rates, dwell times, occupancy priors and alert thresholds are
+   declared, not fitted.
+5. The resident is one person. Others are detected but not tracked.
+6. Daily features use a filtering, not smoothing, approximation.
+
+## 7. Known limitations
+
+Full list in `docs/limitations.rst`. The three that matter most:
+
+**Everything comes from a simulator.** No component has been validated against
+real sensor data. The simulator was written by this project; its generative
+process is deliberately different from the estimator and two guard tests keep
+them apart, but that reduces circularity rather than eliminating it. Every
+number above describes behaviour on this simulator and must not be quoted as an
+estimate of field performance.
+
+**Occupancy and state layers share evidence.** Both consume radar and beacon
+signals, so their errors are dependent and the reported uncertainty does not
+model that.
+
+**Partial record loss remains partly undetectable.** For a sensor with a
+declared cadence, under-delivery is now caught. For a purely event-driven
+sensor there is no promised rate, and a drop in activations is
+indistinguishable from a quieter resident. Where loss correlates with activity
+this biases inference toward inactivity — measured at kitchen recall 0.705 →
+0.180 under 60% activity-correlated loss.
+
+## 8. Remaining risks
+
+| Risk | Severity |
+| --- | --- |
+| Simulator-only validation | **High** |
+| Declared rather than fitted parameters | **High** |
+| Shared evidence between occupancy and state layers | High |
+| Undetectable partial loss on event sensors | Medium |
+| Visitor recall of 0.48; short visits missed | Medium |
+| 168 pre-existing type errors; CI gates `mypy` on two files | Medium |
+| No smoothing or backfill; late records dropped past tolerance | Medium |
+| Unversioned snapshots | Low |
+
+## 9. Recommended future work
+
+In priority order. The first blocks any research claim:
+
+1. **Validate against a public annotated dataset** (CASAS, ARAS, MARBLE) with
+   the same metrics.
+2. **Fit emission and dwell parameters from data**, comparing against the
+   documented defaults.
+3. **Model the occupancy–state dependency** with a joint or hierarchical
+   formulation.
+4. **Improve visitor recall**, currently conservative by construction.
+5. **Assess calibration across households**, not only within one.
+6. **Prospective assessment of alert burden** with people who would act on the
+   alerts, since false-positive tolerance is a human judgement no metric
+   supplies.
+7. Reduce pre-existing type debt and widen the CI `mypy` gate.
+
+## 10. What this remains
+
+Interpretable, probabilistic, privacy-preserving, sensor-agnostic,
+failure-aware, person-context-aware, reproducible, testable, edge-capable.
+
+No large language model is anywhere on the inference or alerting path, and none
+is planned. No neural component is on the inference path. There are no cameras,
+microphones or biometric identification anywhere in the design.
+
+**This is a research toolkit. It is not a medical device, and no claim of
+clinical effectiveness is made or supported anywhere in this repository.**

--- a/sensor_modeling/analysis/pipeline.py
+++ b/sensor_modeling/analysis/pipeline.py
@@ -60,7 +60,10 @@ class AnalysisPipeline:
         ar_model = BernoulliAutoregressiveModel(sensor_names, sensor_names[0])
         hmm_model = BaseHMM()
         cpd_model = EmbeddingCPD()
-        nhpp_model = NHPPPELT(NHPPConfig(n_basis=3, min_seg_len=1))
+        # n_basis must be at least degree+1; the cubic default needs four
+        # basis functions. Below that the model raises on every fit and the
+        # pipeline silently records an error instead of a result.
+        nhpp_model = NHPPPELT(NHPPConfig(n_basis=4, min_seg_len=1))
         return {
             "ar": ar_model,
             "hmm": hmm_model,

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -114,7 +114,35 @@ def test_ablation_command_reports_paired_differences(tmp_path: Path) -> None:
     assert "Paired sensor ablation" in stdout
     assert "95% CI" in stdout
 
+    # The artefact wraps the findings in provenance: results sit under
+    # "results", with configuration, seeds, environment and metric
+    # definitions alongside them.
     payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["experiment"] == "sensor_ablation"
     assert payload["seeds"] == [1, 2]
-    assert "all_modalities" in payload["summary"]
-    assert payload["summary"]["minimal_door_bed"]["n_sensors"] == 2
+    assert payload["environment"]["python"]
+    assert payload["metric_definitions"]["balanced_accuracy"]
+
+    results = payload["results"]
+    assert "all_modalities" in results["summary"]
+    assert results["summary"]["minimal_door_bed"]["n_sensors"] == 2
+
+
+def test_attribution_command_writes_a_provenance_record(tmp_path: Path) -> None:
+    """Regression: wrapping results in provenance changed the artefact shape."""
+    output = tmp_path / "attribution.json"
+    _run_cli(
+        "attribution",
+        "--days",
+        "3",
+        "--seed",
+        "5",
+        "--step-minutes",
+        "60",
+        "--output",
+        str(output),
+    )
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["experiment"] == "attribution_comparison"
+    assert payload["seeds"] == [5]
+    assert "scenarios" in payload["results"]

--- a/tests/test_backwards_compatibility.py
+++ b/tests/test_backwards_compatibility.py
@@ -1,0 +1,190 @@
+"""The original toolkit must keep working unchanged.
+
+The multimodal layer is additive. Every one of these tests exercises an API
+that existed before it, in the way it was used before it, and would fail if
+the newer work had quietly changed behaviour underneath.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import numpy as np
+import pytest
+
+import sensor_modeling
+from sensor_modeling.analysis import AnalysisPipeline, calculate_behavioral_metrics
+from sensor_modeling.change_point import EmbeddingCPD
+from sensor_modeling.hmm import HierarchicalHMM
+from sensor_modeling.models.bernoulli_ar.base_model import BernoulliAutoregressiveModel
+from sensor_modeling.models.change_point_detection.pelt import PELTChangePointDetector
+from sensor_modeling.models.nhpp_pelt.model import NHPPPELT, NHPPConfig
+from sensor_modeling.observations import (
+    Modality,
+    ObservationKind,
+    ObservationStream,
+    SensorRegistry,
+    SensorSpec,
+    observations_from_dataset,
+)
+from sensor_modeling.utils import SensorDataset, simulate_sensor_data
+
+
+@pytest.fixture(scope="module")
+def dataset() -> SensorDataset:
+    """The legacy simulated dataset, generated exactly as before."""
+    return simulate_sensor_data(n_days=3, n_sensors=3, seed=42)
+
+
+class TestOriginalModels:
+    def test_bernoulli_autoregressive_still_fits(self, dataset: SensorDataset) -> None:
+        model = BernoulliAutoregressiveModel(
+            list(dataset.data.columns), dataset.data.columns[0]
+        )
+        result = model.fit(dataset)
+        assert isinstance(result, dict)
+
+    def test_nhpp_pelt_still_fits(self, dataset: SensorDataset) -> None:
+        model = NHPPPELT(NHPPConfig(n_basis=4, min_seg_len=1))
+        model.fit(dataset, sensor=dataset.data.columns[0])
+        assert hasattr(model, "changepoints_")
+
+    def test_the_nhpp_arm_of_the_pipeline_actually_runs(
+        self, dataset: SensorDataset
+    ) -> None:
+        """Regression: the default config violated the model's own constraint.
+
+        `n_basis=3` is below `degree+1` for the cubic default, so every fit
+        raised and the pipeline recorded an error rather than a result. The
+        arm appeared present in the output and had never once worked.
+        """
+        results = AnalysisPipeline().run(dataset)
+        assert "error" not in results["nhpp"]
+        assert "changepoints" in results["nhpp"]
+
+    def test_the_hmm_variants_still_fit_and_predict(
+        self, dataset: SensorDataset
+    ) -> None:
+        model = HierarchicalHMM(n_states=3, random_state=0)
+        values = dataset.data.to_numpy(dtype=float)
+        model.fit(values)
+        states = model.predict(values)
+        assert states.shape[0] == values.shape[0]
+
+    def test_pelt_still_segments(self) -> None:
+        signal = np.concatenate([np.zeros(40), np.ones(40) * 5.0])
+        found = PELTChangePointDetector(penalty=1.0).detect(signal)
+        assert found and 30 <= found[0] <= 50
+
+    def test_the_lightweight_change_point_detectors_still_run(self) -> None:
+        detector = EmbeddingCPD(window=5)
+        detector.fit(np.concatenate([np.zeros(30), np.ones(30)]))
+        assert detector.predict() is not None
+
+    def test_the_analysis_pipeline_still_runs(self, dataset: SensorDataset) -> None:
+        results = AnalysisPipeline().run(dataset)
+        assert set(results) == {"ar", "hmm", "cpd", "nhpp"}
+
+    def test_behavioural_metrics_still_compute(self, dataset: SensorDataset) -> None:
+        metrics = calculate_behavioral_metrics(dataset.data)
+        assert isinstance(metrics, dict)
+
+
+class TestOriginalDataLayer:
+    def test_sensor_dataset_keeps_its_shape(self, dataset: SensorDataset) -> None:
+        assert dataset.data.shape == (3 * 96, 3)
+        assert dataset.to_dataframe() is dataset.data
+
+    def test_simulation_is_still_reproducible(self) -> None:
+        first = simulate_sensor_data(n_days=1, n_sensors=2, seed=7)
+        second = simulate_sensor_data(n_days=1, n_sensors=2, seed=7)
+        assert first.data.equals(second.data)
+
+    def test_event_sequences_still_extract(self, dataset: SensorDataset) -> None:
+        events = dataset.to_event_sequences(dataset.data.columns[0])
+        assert isinstance(events, list)
+
+
+class TestPublicSurface:
+    def test_the_original_subpackages_are_still_advertised(self) -> None:
+        for name in (
+            "models",
+            "analysis",
+            "utils",
+            "change_point",
+            "hmm",
+            "data",
+            "visualization",
+        ):
+            assert name in sensor_modeling.__all__
+
+    def test_the_version_is_still_exposed(self) -> None:
+        assert sensor_modeling.__version__
+
+
+class TestBridgeBetweenLayers:
+    def test_a_legacy_dataset_reaches_the_new_pipeline(
+        self, dataset: SensorDataset
+    ) -> None:
+        """The additive claim, demonstrated end to end."""
+        registry = SensorRegistry.from_specs(
+            [
+                SensorSpec(name, Modality.MOTION, room=f"room_{index}")
+                for index, name in enumerate(dataset.data.columns)
+            ]
+        )
+        observations = list(
+            observations_from_dataset(dataset, registry, tz=None)
+            if dataset.data.index.tz is not None
+            else observations_from_dataset(
+                dataset, registry, tz=__import__("datetime").timezone.utc
+            )
+        )
+        assert observations
+        assert all(obs.modality is Modality.MOTION for obs in observations)
+
+    def test_new_observations_frame_back_into_the_legacy_shape(
+        self, dataset: SensorDataset
+    ) -> None:
+        from datetime import timezone
+
+        registry = SensorRegistry.from_specs(
+            [SensorSpec(name, Modality.MOTION) for name in dataset.data.columns]
+        )
+        stream = ObservationStream.from_observations(
+            observations_from_dataset(dataset, registry, tz=timezone.utc)
+        )
+        frame = stream.event_counts("15min", sensor_ids=list(dataset.data.columns))
+        assert list(frame.columns) == list(dataset.data.columns)
+        assert frame.index.tz is not None
+
+    def test_the_two_layers_disagree_about_nothing_they_share(
+        self, dataset: SensorDataset
+    ) -> None:
+        """Total activations must survive the round trip."""
+        from datetime import timezone
+
+        registry = SensorRegistry.from_specs(
+            [SensorSpec(name, Modality.MOTION) for name in dataset.data.columns]
+        )
+        stream = ObservationStream.from_observations(
+            observations_from_dataset(dataset, registry, tz=timezone.utc)
+        )
+        counts = stream.event_counts("15min", sensor_ids=list(dataset.data.columns))
+        for column in dataset.data.columns:
+            assert counts[column].sum() == dataset.data[column].sum()
+
+    def test_a_state_sensor_declaration_changes_only_the_framing(self) -> None:
+        """The same records framed as states rather than events."""
+        from datetime import timezone
+
+        data = simulate_sensor_data(n_days=1, n_sensors=1, seed=3)
+        column = data.data.columns[0]
+        registry = SensorRegistry.from_specs(
+            [SensorSpec(column, Modality.BED_PRESSURE, kind=ObservationKind.STATE)]
+        )
+        stream = ObservationStream.from_observations(
+            observations_from_dataset(data, registry, tz=timezone.utc)
+        )
+        states = stream.state_frame("15min", max_hold=timedelta(hours=1))
+        assert column in states.columns


### PR DESCRIPTION
Verifies the pipeline end to end, confirms the original models still work, and records the review for a human deciding on a version bump. Recommends 0.2.0; nothing merged to main, tagged or published.

Fixes two defects found by the review: the analysis pipeline's NHPP arm had never worked, because its default n_basis violated the model's own constraint; and wrapping experiment results in provenance nested the findings, breaking a CLI test that had not been re-run.

Adds README supported/unsupported claims and backwards-compatibility tests. No new dependencies.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records the final integration review for the 0.2.0 release and fixes two defects it found: the NHPP analysis arm had never produced a result, and the provenance-wrapped experiment artefact broke a CLI test asserting the old flat shape.

**Fixes**
- The NHPP arm now defaults to `n_basis=4`, satisfying the model's `n_basis >= degree+1` constraint; previously every fit raised and the pipeline recorded an error instead of a result.
- The CLI integration test now expects findings under `results` in the provenance record, and the attribution command is covered by a regression test.

**Release readiness**
- Adds `docs/RELEASE_READINESS.md` covering quality gates, evaluation results, backwards compatibility, and remaining risks.
- Adds backwards-compatibility tests exercising the original models, data layer, and public surface.
- Adds supported and unsupported claims to the README; the version bump is recommended but nothing has been merged, tagged, or published.

<sup>Written for commit 42279f501d55108be0423f4687aa88ee6171a608. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/70?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

