### PR TITLE
Repair lint, widen its scope, refresh release dates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,21 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install -e .[dev]
+      # Pull requests lint only what they changed, which keeps them fast.
+      # Pushes to a shared branch lint everything, because the changed-files
+      # scope cannot see breakage that arrived in an earlier merge: a red lint
+      # merged anyway stays red in the tree while every later run reports
+      # success, having checked somebody else's files.
       - name: Run pre-commit on changed files
+        if: github.event_name == 'pull_request'
         shell: bash
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            pre-commit run --from-ref "origin/${{ github.base_ref }}" --to-ref HEAD
-          else
-            pre-commit run --from-ref "${{ github.event.before }}" --to-ref "${{ github.sha }}"
-          fi
+          pre-commit run --from-ref "origin/${{ github.base_ref }}" --to-ref HEAD
+      - name: Run pre-commit on all files
+        if: github.event_name != 'pull_request'
+        shell: bash
+        run: |
+          pre-commit run --all-files
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0] - 2026-08-29
+## [0.2.0] - 2026-08-30
 
 Extends the toolkit into a multimodal ambient-sensing research platform. The
 work is additive: no public symbol was removed or changed, and a user of
@@ -46,6 +46,7 @@ has not been validated against real sensor data. See `docs/limitations.md`.
 - Added guard tests importing every module and rejecting shared container defaults on dataclass fields, so a version-specific failure of this kind fails on any interpreter.
 - Added `git_commit`, `git_dirty`, `schema_version` and a snapshot of resolved algorithm defaults to experiment provenance, so a record identifies the exact code and model specification behind it rather than only a package version.
 - Added a `gate` job aggregating lint, test, docs and package into a single required check.
+- Changed the lint job to check every file on pushes to a shared branch, keeping the fast changed-files scope for pull requests. The narrow scope could not see breakage that arrived in an earlier merge, so a red lint merged anyway stayed red in the tree while every later run reported success after checking unrelated files.
 - Added `docs/MULTIMODAL_ARCHITECTURE.md`, `docs/RESEARCH_QUESTIONS.md`, `docs/SENSOR_DATA_MODEL.md`, `docs/UNCERTAINTY_MODEL.md`, `docs/EVALUATION_DESIGN.md`, `docs/ADVERSARIAL_REVIEW.md`, `docs/RELEASE_READINESS.md` and `docs/multimodal_ingestion.md`.
 - Added backwards-compatibility tests exercising the original models, data layer and public surface.
 - Added `docs/ambient_architecture.md`, `docs/inference.md`, `docs/evaluation.md`, and `docs/limitations.md`.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -28,7 +28,7 @@ repository-artifact: "https://zenodo.org/records/17070041"
 url: "https://sensor-modeling.readthedocs.io"
 
 version: "0.2.0"
-date-released: "2026-08-29"
+date-released: "2026-08-30"
 license: MIT
 license-url: "https://opensource.org/licenses/MIT"
 

--- a/papers/failure-aware-multimodal-behavioural-sensing/experiments/run_confirmatory.py
+++ b/papers/failure-aware-multimodal-behavioural-sensing/experiments/run_confirmatory.py
@@ -19,7 +19,6 @@ import json
 import math
 import subprocess
 from collections import defaultdict
-from dataclasses import asdict, replace
 from datetime import timedelta
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
@@ -34,7 +33,13 @@ from sensor_modeling.evaluation import (
 )
 from sensor_modeling.health.monitor import SensorHealthReport, SystemHealthReport
 from sensor_modeling.online import BehaviouralSensingPipeline, PipelineConfig
-from sensor_modeling.simulation import DegradationConfig, HouseholdConfig, degrade, dropout, simulate
+from sensor_modeling.simulation import (
+    DegradationConfig,
+    HouseholdConfig,
+    degrade,
+    dropout,
+    simulate,
+)
 
 HERE = Path(__file__).resolve().parent
 DEFAULT_CONFIG = HERE / "config.json"
@@ -225,9 +230,7 @@ def _run_h2(
     return {"rows": rows}
 
 
-def _scenarios_for_seed(
-    config: Mapping[str, Any], seed: int
-) -> list[Scenario]:
+def _scenarios_for_seed(config: Mapping[str, Any], seed: int) -> list[Scenario]:
     from sensor_modeling.evaluation.attribution import standard_scenarios
 
     available = {
@@ -281,7 +284,9 @@ def _run_h4(
         )
         observations, dropped = degrade(household.observations, degradation)
         aware = _pipeline_metrics(household, observations, step=step, health_aware=True)
-        naive = _pipeline_metrics(household, observations, step=step, health_aware=False)
+        naive = _pipeline_metrics(
+            household, observations, step=step, health_aware=False
+        )
         for arm, metrics in (("failure_aware", aware), ("health_naive", naive)):
             rows.append(
                 {
@@ -307,7 +312,9 @@ def _run_h5(
                 "full": all_sensors,
                 "without_first": tuple(s for s in all_sensors if s != first),
                 "without_second": tuple(s for s in all_sensors if s != second),
-                "without_both": tuple(s for s in all_sensors if s not in {first, second}),
+                "without_both": tuple(
+                    s for s in all_sensors if s not in {first, second}
+                ),
             }
             values: dict[str, float] = {}
             for name, sensors in configurations.items():
@@ -339,9 +346,7 @@ def _run_h5(
     return {"rows": rows}
 
 
-def _summaries(
-    config: Mapping[str, Any], results: Mapping[str, Any]
-) -> dict[str, Any]:
+def _summaries(config: Mapping[str, Any], results: Mapping[str, Any]) -> dict[str, Any]:
     confidence = float(config["reporting"]["confidence_level"])
     resamples = int(config["reporting"]["bootstrap_resamples"])
     output: dict[str, Any] = {}
@@ -453,7 +458,11 @@ def _write_csv(path: Path, rows: Sequence[Mapping[str, Any]]) -> None:
     for row in rows:
         scalar_rows.append(
             {
-                key: json.dumps(value, sort_keys=True) if isinstance(value, (dict, list)) else value
+                key: (
+                    json.dumps(value, sort_keys=True)
+                    if isinstance(value, (dict, list))
+                    else value
+                )
                 for key, value in row.items()
             }
         )


### PR DESCRIPTION
`develop` currently fails lint. #76 merged with a red lint job, and every run since has reported success because the lint step only checks files the current change touched, so it was checking somebody else's. Three ruff errors and a black reformat in the paper runner, fixed.

The scope is the real defect: pull requests keep the fast changed-files check, pushes to a shared branch now run pre-commit over everything. `pre-commit run --all-files` passes on the tree with the fix applied.

Release dates moved to 2026-08-30 in CHANGELOG and CITATION.cff.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the lint job so shared-branch pushes check every file instead of only changed files, which let a red lint merged into `develop` keep failing while every later run reported success. Repairs three ruff errors and a black reformat in the paper runner, and moves the release date to 2026-08-30.

**Bug Fixes**
- Pull requests keep the fast changed-files scope.
- Pushes to a shared branch run `pre-commit run --all-files`.
- Release date moved to 2026-08-30 in `CHANGELOG.md` and `CITATION.cff`.

<sup>Written for commit 5a944426590fcc01e0765a640aa2074d1103eb7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

