### PR TITLE
Fix paper runner formatting gate

### DIFF
--- a/papers/failure-aware-multimodal-behavioural-sensing/experiments/run_confirmatory.py
+++ b/papers/failure-aware-multimodal-behavioural-sensing/experiments/run_confirmatory.py
@@ -29,7 +29,12 @@ from typing import Any
 
 import numpy as np
 
-from sensor_modeling.evaluation import Scenario, compare_scenario, named_subsets, state_metrics
+from sensor_modeling.evaluation import (
+    Scenario,
+    compare_scenario,
+    named_subsets,
+    state_metrics,
+)
 from sensor_modeling.evaluation.attribution import standard_scenarios
 from sensor_modeling.health.monitor import SensorHealthReport, SystemHealthReport
 from sensor_modeling.online import BehaviouralSensingPipeline, PipelineConfig
@@ -563,7 +568,7 @@ def _summaries(
 
     h5_groups: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
     for row in results["h5"]:
-        h5_groups[f"{row['first_sensor']} + {row['second_sensor']}"] .append(row)
+        h5_groups[f"{row['first_sensor']} + {row['second_sensor']}"].append(row)
     output["h5"] = {
         pair: _sample_summary(
             _values(rows, "interaction"),
@@ -576,7 +581,9 @@ def _summaries(
     return output
 
 
-def _mcse_gate(config: Mapping[str, Any], summary: Mapping[str, Any]) -> dict[str, Any]:
+def _mcse_gate(
+    config: Mapping[str, Any], summary: Mapping[str, Any]
+) -> dict[str, Any]:
     """Apply the pre-specified precision gate to H2 balanced-accuracy gaps."""
     target = float(config["replications"]["monte_carlo_se_target"])
     observed = [
@@ -667,7 +674,11 @@ def run(config: Mapping[str, Any], seeds: Sequence[int]) -> dict[str, Any]:
         "h5": _run_h5(config, seeds, step),
     }
     summary = _summaries(config, raw)
-    return {"raw": raw, "summaries": summary, "mcse_gate": _mcse_gate(config, summary)}
+    return {
+        "raw": raw,
+        "summaries": summary,
+        "mcse_gate": _mcse_gate(config, summary),
+    }
 
 
 def _confirmatory_status(


### PR DESCRIPTION
Corrects the remaining pre-commit failure on the paper confirmatory runner after PR #77 merged. The change is formatting-only: canonical import layout, removal of a stray space before an H5 `.append()` call, and Black-style wrapping of long expressions. No hypothesis, DGP, model, experiment configuration, replication threshold, MCSE target, or result logic changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the remaining pre-commit formatting failure on the paper confirmatory runner after merging PR #77.

- Applies canonical import layout and Black-style wrapping to long expressions.
- Removes a stray space before an `.append()` call and adds a trailing newline at end of file.
- No hypothesis, DGP, model, experiment configuration, replication threshold, MCSE target, or result logic changes.

<sup>Written for commit 7a95d0f6fd7a8140313bc408a5483f161c2c8ec0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/79?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

