### PR TITLE
Restore known-green paper runner

### DIFF
--- a/papers/failure-aware-multimodal-behavioural-sensing/experiments/run_confirmatory.py
+++ b/papers/failure-aware-multimodal-behavioural-sensing/experiments/run_confirmatory.py
@@ -579,9 +579,7 @@ def _summaries(
     return output
 
 
-def _mcse_gate(
-    config: Mapping[str, Any], summary: Mapping[str, Any]
-) -> dict[str, Any]:
+def _mcse_gate(config: Mapping[str, Any], summary: Mapping[str, Any]) -> dict[str, Any]:
     """Apply the pre-specified precision gate to H2 balanced-accuracy gaps."""
     target = float(config["replications"]["monte_carlo_se_target"])
     observed = [
@@ -672,11 +670,7 @@ def run(config: Mapping[str, Any], seeds: Sequence[int]) -> dict[str, Any]:
         "h5": _run_h5(config, seeds, step),
     }
     summary = _summaries(config, raw)
-    return {
-        "raw": raw,
-        "summaries": summary,
-        "mcse_gate": _mcse_gate(config, summary),
-    }
+    return {"raw": raw, "summaries": summary, "mcse_gate": _mcse_gate(config, summary)}
 
 
 def _confirmatory_status(


### PR DESCRIPTION
Restores the exact `run_confirmatory.py` blob from commit `5a944426590fcc01e0765a640aa2074d1103eb7d`, whose CI run #132 completed successfully across lint, Python 3.10/3.11/3.12 tests, docs, package, and the aggregate gate.

This is a byte-for-byte restoration of the already-validated runner after PR #79 inadvertently reintroduced an older formatting state. No experiment design, hypotheses, DGP, sensor subsets, thresholds, or result logic change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the known-green version of `run_confirmatory.py` after a prior PR accidentally reintroduced an older formatting state. The script is now byte-for-byte identical to the previously validated version; no experiment logic, thresholds, or result handling change.

<sup>Written for commit 713654926eaa3a67ac9eda99ce5be8d75e27fd7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

