### PR TITLE
Make PR CI path-aware for papers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,92 @@ on:
   pull_request:
 
 jobs:
+  changes:
+    name: classify changes
+    runs-on: ubuntu-latest
+    outputs:
+      paper_only: ${{ steps.classify.outputs.paper_only }}
+      paper_python: ${{ steps.classify.outputs.paper_python }}
+      full_repo: ${{ steps.classify.outputs.full_repo }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: classify
+        name: Classify changed paths
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "paper_only=false" >> "$GITHUB_OUTPUT"
+            echo "paper_python=false" >> "$GITHUB_OUTPUT"
+            echo "full_repo=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          mapfile -t files < <(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+          if (( ${#files[@]} == 0 )); then
+            echo "paper_only=false" >> "$GITHUB_OUTPUT"
+            echo "paper_python=false" >> "$GITHUB_OUTPUT"
+            echo "full_repo=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          paper_only=true
+          paper_python=false
+          for file in "${files[@]}"; do
+            if [[ "$file" != papers/* ]]; then
+              paper_only=false
+            fi
+            if [[ "$file" == papers/*.py || "$file" == papers/**/*.py ]]; then
+              paper_python=true
+            fi
+          done
+
+          echo "paper_only=$paper_only" >> "$GITHUB_OUTPUT"
+          echo "paper_python=$paper_python" >> "$GITHUB_OUTPUT"
+          if [[ "$paper_only" == "true" ]]; then
+            echo "full_repo=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "full_repo=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  paper:
+    name: paper checks
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.paper_only == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Check whitespace and patch integrity
+        run: git diff --check "origin/${{ github.base_ref }}...HEAD"
+      - name: Validate paper JSON files
+        shell: bash
+        run: |
+          while IFS= read -r file; do
+            python -m json.tool "$file" >/dev/null
+          done < <(find papers -type f -name '*.json' -print)
+      - name: Set up Python
+        if: needs.changes.outputs.paper_python == 'true'
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Install paper formatters
+        if: needs.changes.outputs.paper_python == 'true'
+        run: pip install 'ruff==0.11.13' 'black==23.9.1'
+      - name: Check paper Python
+        if: needs.changes.outputs.paper_python == 'true'
+        shell: bash
+        run: |
+          mapfile -t files < <(find papers -type f -name '*.py' -print)
+          python -m py_compile "${files[@]}"
+          ruff check "${files[@]}"
+          black --check --line-length=88 "${files[@]}"
+
   lint:
+    needs: changes
+    if: needs.changes.outputs.full_repo == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -20,11 +105,6 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install -e .[dev]
-      # Pull requests lint only what they changed, which keeps them fast.
-      # Pushes to a shared branch lint everything, because the changed-files
-      # scope cannot see breakage that arrived in an earlier merge: a red lint
-      # merged anyway stays red in the tree while every later run reports
-      # success, having checked somebody else's files.
       - name: Run pre-commit on changed files
         if: github.event_name == 'pull_request'
         shell: bash
@@ -35,7 +115,10 @@ jobs:
         shell: bash
         run: |
           pre-commit run --all-files
+
   test:
+    needs: changes
+    if: needs.changes.outputs.full_repo == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -57,6 +140,8 @@ jobs:
           pytest --cov=sensor_modeling --cov-report=xml --cov-report=term
 
   docs:
+    needs: changes
+    if: needs.changes.outputs.full_repo == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -77,8 +162,6 @@ jobs:
           name: documentation-html
           path: site/
           retention-days: 7
-      # Kept separate from the strict build, and non-blocking: an external site
-      # going down is not a reason to fail a release.
       - name: Check links
         continue-on-error: true
         run: |
@@ -86,6 +169,8 @@ jobs:
           linkchecker --no-warnings --ignore-url='^(?!file://)' site/index.html
 
   package:
+    needs: changes
+    if: needs.changes.outputs.full_repo == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -104,22 +189,31 @@ jobs:
         run: |
           python -m twine check dist/*
 
-  # A single required check. Branch protection points at this one job, so a
-  # failure anywhere in the matrix blocks the merge rather than needing every
-  # job to be listed and kept in sync.
   gate:
     name: all checks passed
     runs-on: ubuntu-latest
-    needs: [lint, test, docs, package]
+    needs: [changes, paper, lint, test, docs, package]
     if: always()
     steps:
-      - name: Fail if any required job did not succeed
+      - name: Verify required checks for this change class
+        shell: bash
         run: |
+          if [[ "${{ needs.changes.result }}" != "success" ]]; then
+            echo "::error::change classification failed"
+            exit 1
+          fi
+
+          if [[ "${{ needs.changes.outputs.paper_only }}" == "true" ]]; then
+            echo "paper -> ${{ needs.paper.result }}"
+            [[ "${{ needs.paper.result }}" == "success" ]] || exit 1
+            exit 0
+          fi
+
           results="${{ needs.lint.result }} ${{ needs.test.result }} ${{ needs.docs.result }} ${{ needs.package.result }}"
           echo "lint test docs package -> $results"
           for result in $results; do
-            if [ "$result" != "success" ]; then
-              echo "::error::a required job did not succeed; this branch is not mergeable"
+            if [[ "$result" != "success" ]]; then
+              echo "::error::a required repository job did not succeed"
               exit 1
             fi
           done


### PR DESCRIPTION
Changes CI classification so paper-only pull requests under `papers/**` use a lightweight paper gate instead of the full package/test/docs matrix.

Behaviour:
- paper-only PR: classify paths, run whitespace/patch checks, validate paper JSON, and only if paper Python is touched run `py_compile`, Ruff, and Black;
- core/package/docs/workflow or mixed PR: run the existing full lint + Python 3.10/3.11/3.12 + docs + package checks;
- pushes to `develop`/`main`: always run the full repository gate, preserving shared-branch health validation.

This is a CI-scope change only. It does not alter the paper, experiment design, simulator, package code, or scientific thresholds.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes CI path-aware so paper-only PRs no longer trigger the full lint/test/docs/package matrix.

- Adds a change-classification job that detects whether a PR touches only `papers/**`.
- Paper-only PRs run whitespace checks, paper JSON validation, and—only if paper Python files changed—`py_compile`, Ruff, and Black.
- Mixed or core PRs keep the existing full matrix; pushes to `develop`/`main` always run the full gate.
- The required `gate` job now verifies whichever check set applies, so merge blocking stays consistent.
- CI-scope only; no changes to paper content, experiment design, simulator, package code, or scientific thresholds.

<sup>Written for commit 49476236872c6137444f473f07b39f2ff85d0045. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

