### PR TITLE
Add paper experiment smoke workflow

### DIFF
--- a/.github/workflows/paper-smoke.yml
+++ b/.github/workflows/paper-smoke.yml
@@ -1,0 +1,76 @@
+name: Paper experiment smoke
+
+on:
+  pull_request:
+    paths:
+      - 'papers/failure-aware-multimodal-behavioural-sensing/experiments/**'
+      - '.github/workflows/paper-smoke.yml'
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Install runtime dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -e .
+      - name: Validate frozen experiment specification
+        run: |
+          python papers/failure-aware-multimodal-behavioural-sensing/experiments/run_confirmatory.py \
+            --validate-only \
+            --replications 2
+      - name: Run two-household smoke study
+        run: |
+          python papers/failure-aware-multimodal-behavioural-sensing/experiments/run_confirmatory.py \
+            --replications 2 \
+            --output paper-smoke-results
+      - name: Assert smoke outputs
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          root = Path('paper-smoke-results')
+          required = {
+              'confirmatory_results.json',
+              'h1.csv',
+              'h2.csv',
+              'h3.csv',
+              'h4.csv',
+              'h5.csv',
+              'generated_results.tex',
+          }
+          missing = sorted(name for name in required if not (root / name).is_file())
+          if missing:
+              raise SystemExit(f'missing smoke outputs: {missing}')
+
+          artifact = json.loads((root / 'confirmatory_results.json').read_text())
+          if artifact['status'] != 'pilot-or-incomplete':
+              raise SystemExit(
+                  f"two-household smoke run must not be confirmatory: {artifact['status']}"
+              )
+          if len(artifact['seeds']) != 2:
+              raise SystemExit('smoke run did not use exactly two household seeds')
+          if artifact['git']['dirty'] is not False:
+              raise SystemExit(f"smoke run provenance is dirty: {artifact['git']}")
+          if artifact['git']['commit'] == 'unknown':
+              raise SystemExit('smoke run did not record a Git commit')
+
+          for hypothesis in ('h1', 'h2', 'h3', 'h4', 'h5'):
+              if not artifact['results']['raw'][hypothesis]:
+                  raise SystemExit(f'{hypothesis} produced no rows')
+          PY
+      - name: Upload smoke outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: paper-experiment-smoke
+          path: paper-smoke-results/
+          retention-days: 14


### PR DESCRIPTION
Adds a dedicated, narrow smoke workflow for the methodological paper experiment.

It triggers only when the paper experiment code/config changes (or on manual dispatch), not for ordinary `main.tex`/bibliography edits. The workflow installs the runtime package on Python 3.11, validates the frozen experiment specification, runs H1–H5 with exactly two paired household seeds, asserts that the output remains `pilot-or-incomplete`, verifies Git provenance and all expected JSON/CSV/LaTeX outputs, and uploads the bundle as a 14-day artifact.

This does not alter the manuscript, experiment design, simulator, hypotheses, sensor subsets, N=200 minimum, or MCSE threshold.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated smoke workflow for the methodological paper experiment so experiment code changes get validated without affecting the manuscript.

- Triggers only on experiment path changes or manual dispatch, not on `main.tex` or bibliography edits.
- Installs the runtime on Python 3.11, validates the frozen spec, and runs H1–H5 with exactly two paired household seeds.
- Asserts the output remains `pilot-or-incomplete`, Git provenance is clean, and all expected JSON/CSV/LaTeX files exist.
- Uploads the result bundle as a 14-day artifact.

<sup>Written for commit 52a396f636bb203014e800f9c2261f33239ac523. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/82?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

