### PR TITLE
Shorten paper smoke execution

### DIFF
--- a/.github/workflows/paper-smoke.yml
+++ b/.github/workflows/paper-smoke.yml
@@ -5,6 +5,11 @@ on:
     paths:
       - 'papers/failure-aware-multimodal-behavioural-sensing/experiments/**'
       - '.github/workflows/paper-smoke.yml'
+  push:
+    branches: [develop]
+    paths:
+      - 'papers/failure-aware-multimodal-behavioural-sensing/experiments/**'
+      - '.github/workflows/paper-smoke.yml'
   workflow_dispatch:
 
 jobs:
@@ -27,9 +32,16 @@ jobs:
           python papers/failure-aware-multimodal-behavioural-sensing/experiments/run_confirmatory.py \
             --validate-only \
             --replications 2
-      - name: Run two-household smoke study
+      - name: Validate integration smoke specification
         run: |
           python papers/failure-aware-multimodal-behavioural-sensing/experiments/run_confirmatory.py \
+            --config papers/failure-aware-multimodal-behavioural-sensing/experiments/smoke_config.json \
+            --validate-only \
+            --replications 2
+      - name: Run short two-household smoke study
+        run: |
+          python papers/failure-aware-multimodal-behavioural-sensing/experiments/run_confirmatory.py \
+            --config papers/failure-aware-multimodal-behavioural-sensing/experiments/smoke_config.json \
             --replications 2 \
             --output paper-smoke-results
       - name: Assert smoke outputs
@@ -57,6 +69,8 @@ jobs:
               raise SystemExit(
                   f"two-household smoke run must not be confirmatory: {artifact['status']}"
               )
+          if artifact['resolved_config']['status'] != 'integration-smoke-only':
+              raise SystemExit('smoke workflow did not use smoke_config.json')
           if len(artifact['seeds']) != 2:
               raise SystemExit('smoke run did not use exactly two household seeds')
           if artifact['git']['dirty'] is not False:

--- a/papers/failure-aware-multimodal-behavioural-sensing/experiments/smoke_config.json
+++ b/papers/failure-aware-multimodal-behavioural-sensing/experiments/smoke_config.json
@@ -1,0 +1,102 @@
+{
+  "schema_version": 1,
+  "status": "integration-smoke-only",
+  "paper": "Failure-Aware Multimodal Behavioural Sensing",
+  "replications": {
+    "minimum": 200,
+    "seed_start": 10000,
+    "monte_carlo_se_target": 0.002,
+    "maximum": 1000
+  },
+  "household": {
+    "days": 3,
+    "step_minutes": 60
+  },
+  "primary_metrics": [
+    "balanced_accuracy",
+    "log_loss",
+    "brier",
+    "calibration_error",
+    "abstention_rate"
+  ],
+  "h1_missingness": {
+    "rates": [0.0, 0.05, 0.10, 0.20, 0.40]
+  },
+  "h2_sensor_subsets": {
+    "all_modalities": [
+      "front_door",
+      "bedroom_motion",
+      "bathroom_motion",
+      "kitchen_motion",
+      "living_motion",
+      "fridge_contact",
+      "bed_pressure",
+      "living_radar",
+      "wearable_motion",
+      "resident_beacon"
+    ],
+    "object_sensors_only": [
+      "front_door",
+      "bedroom_motion",
+      "bathroom_motion",
+      "kitchen_motion",
+      "living_motion",
+      "fridge_contact"
+    ],
+    "objects_plus_wearable": [
+      "front_door",
+      "bedroom_motion",
+      "bathroom_motion",
+      "kitchen_motion",
+      "living_motion",
+      "fridge_contact",
+      "wearable_motion",
+      "resident_beacon"
+    ],
+    "radar_door_bed": [
+      "front_door",
+      "living_radar",
+      "bed_pressure"
+    ],
+    "radar_door_bed_wearable": [
+      "front_door",
+      "living_radar",
+      "bed_pressure",
+      "wearable_motion",
+      "resident_beacon"
+    ],
+    "minimal_door_bed": [
+      "front_door",
+      "bed_pressure"
+    ]
+  },
+  "h3_attribution_scenarios": [
+    "resident_alone",
+    "short_visitor",
+    "prolonged_visitor",
+    "carer_visits",
+    "visitor_and_carer",
+    "resident_without_wearable",
+    "no_radar",
+    "sparse_coverage"
+  ],
+  "h4_failures": {
+    "missing_rate": 0.30,
+    "sensor_dropout": "bed_pressure",
+    "dropout_start_day": 1,
+    "dropout_days": 1
+  },
+  "h5_interactions": [
+    ["living_radar", "resident_beacon"],
+    ["wearable_motion", "resident_beacon"],
+    ["front_door", "resident_beacon"],
+    ["bed_pressure", "wearable_motion"]
+  ],
+  "reporting": {
+    "confidence_level": 0.95,
+    "bootstrap_resamples": 100,
+    "paired_by_seed": true,
+    "time_points_are_not_replications": true,
+    "field_performance_claims_forbidden": true
+  }
+}


### PR DESCRIPTION
Corrects the paper smoke workflow so it validates the real frozen `config.json` unchanged but executes H1–H5 on a separate integration-only smoke configuration.

The smoke configuration preserves every hypothesis path, sensor subset, attribution scenario and interaction pair, while shortening the synthetic horizon from 70 days to 3 days, using 60-minute steps, shortening the H4 dropout window, and reducing bootstrap resamples to 100. It retains the confirmatory N/MCSE fields solely so the runner schema and non-confirmatory guard remain exercised; its status is explicitly `integration-smoke-only`.

The workflow also runs on experiment changes pushed to `develop`, so the merged revision is exercised rather than only the PR head. The production confirmatory config, hypotheses, DGP, N=200 minimum and MCSE <= 0.002 threshold are unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shortens the paper smoke workflow by running H1–H5 on a dedicated integration-only config while still validating the frozen confirmatory `config.json` unchanged.

- Adds `smoke_config.json` that keeps every hypothesis path, sensor subset, attribution scenario, and interaction pair but shortens the synthetic horizon to 3 days with 60-minute steps, shortens the H4 dropout window, and drops bootstrap resamples to 100.
- Keeps the confirmatory N/MCSE fields in the smoke config only so the runner schema and non-confirmatory guard stay exercised; its status is `integration-smoke-only`.
- Runs the workflow on pushes to `develop` so the merged revision is exercised, not just the PR head.
- The production confirmatory config, hypotheses, DGP, N=200 minimum, and MCSE <= 0.002 threshold are unchanged.

<sup>Written for commit 01213ec5f5135814ac37519c37aeb081c6828835. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/84?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

