### PR TITLE
Read CASAS recordings into the canonical model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `sensor_modeling.datasets`, bringing published annotated recordings into the canonical observation model so the pipeline can be run over data this project did not generate. The CASAS adapter refuses to guess a timezone, refuses to label unannotated time, and refuses to force unrecognised sensors or activity labels into the ontology, reporting each as discarded rather than admitting it as evidence. `evaluate_recording` scores the unmodified pipeline and reports coverage beside the metrics, and refuses to score a recording in which nothing carried a mapped label.
+- Added `docs/real_data.md` describing what the adapter will not do and why, and stating plainly that the shipped integration test uses a CASAS-format fixture written by this repository rather than a real recording.
+
 ### Changed
 - Moved every citation target to concept DOI `10.5281/zenodo.21337272`. Zenodo minted a new concept lineage when `0.2.0` was archived through the GitHub integration rather than adding a version to the existing one, so `10.5281/zenodo.17070041` now resolves to `0.1.0` alone and no longer stands for all versions. The `0.2.0` record links back with `isNewVersionOf`, and `ZENODO.md` documents both lineages.
 

--- a/docs/real_data.md
+++ b/docs/real_data.md
@@ -1,0 +1,103 @@
+# Real-data validation
+
+Every quantitative result elsewhere in this documentation comes from the
+simulator bundled with this repository. The simulator and the inference model
+are deliberately different in structure, and guard tests check that ground truth
+does not leak between them, so those results are not circular. They still only
+establish properties of the inference model, not of any real home.
+
+`sensor_modeling.datasets` exists to close that gap: it brings published,
+annotated recordings into the same canonical observation model, so the same
+pipeline can be run over data this project did not generate.
+
+## What is implemented
+
+An adapter for [CASAS](https://casas.wsu.edu/datasets/) recordings, and a runner
+that scores the unmodified pipeline against their annotations.
+
+```python
+from datetime import timedelta
+from zoneinfo import ZoneInfo
+
+from sensor_modeling.datasets import read_casas, evaluate_recording
+
+recording = read_casas(
+    "aruba/data",
+    timezone=ZoneInfo("America/Los_Angeles"),
+    rooms={"M003": "kitchen", "M004": "bedroom"},
+)
+print(recording.summary())
+
+result = evaluate_recording(recording, step=timedelta(minutes=10))
+print(result.to_dict())
+```
+
+Recordings are not redistributed with this package. Download them from CASAS
+under the terms stated there.
+
+## What the adapter refuses to do
+
+Three conveniences that would each produce a better-looking number and a worse
+result.
+
+**It will not guess a timezone.** CASAS timestamps are naive local wall-clock.
+Reading them as UTC displaces every event by hours, which is invisible in
+aggregate counts and fatal to anything involving daily rhythm. `timezone` is a
+required argument.
+
+**It will not label unlabelled time.** Much of a recording carries no
+annotation. `truth_series` returns `None` there and the metrics skip those
+positions. Filling gaps with a plausible state would manufacture agreement.
+
+**It will not force sensors or activities into the ontology.** A light switch or
+power meter has no unambiguous canonical modality, so it is excluded and named
+in `unmapped_sensors` rather than admitted as `OTHER`, where it would push the
+posterior around under a modality nobody reasoned about. Activity labels with no
+counterpart are reported in `unmapped_activities` rather than collapsed into
+`UNKNOWN`, which is a claim about abstention and not a place to put vocabulary
+gaps.
+
+## Choices that affect the result
+
+**Rooms must be supplied.** Raw CASAS files carry no machine-readable
+sensor-to-room map, and the occupancy and fusion layers key on rooms. Inferring
+one from sensor numbering would be fabrication, so `rooms` is optional and unset
+by default — and the pipeline will do poorly without it. Build the map from the
+apartment's floor plan in the dataset documentation.
+
+**Only activations become observations.** Motion and door sensors report
+ON/OFF and OPEN/CLOSE pairs. The pipeline models these as event-kind sensors
+whose rate carries the information, so admitting both halves would double every
+count. The discarded readings are counted in `deactivations`. Treating them as
+state-kind evidence instead is a legitimate alternative this adapter does not
+take.
+
+**`Eating` maps to `HOME_ACTIVE`, not `KITCHEN_ACTIVITY`.** The ontology's
+kitchen state means being active in the kitchen, and meals are often eaten
+elsewhere. Mapping it to the kitchen would manufacture agreement with an
+inference that keys on kitchen sensors. Pass `activity_states` to decide
+differently; the point is that the decision is visible.
+
+## Read coverage before reading accuracy
+
+`DatasetEvaluation` reports `scored`, `scored_fraction` and `labelled_fraction`
+alongside the metrics, deliberately in the same structure. A balanced accuracy
+computed over a tenth of a recording is a different claim from one computed over
+most of it, and separating the two invites a reader to forget the difference.
+
+Scoring is refused outright when nothing carried a mapped label, because a
+metric over an empty sample still prints as a number.
+
+## Status
+
+The adapter is implemented and tested end to end, including an integration test
+that runs a CASAS-format recording through the unmodified pipeline. **That
+fixture is synthesised by this repository in CASAS format.** It establishes that
+the plumbing is correct and that the declared emission defaults separate states
+without being refitted. It says nothing about performance on a real apartment.
+
+Running this against downloaded CASAS recordings, and reporting what happens, is
+the outstanding work — and the answer is genuinely unknown. Nothing in the
+package is tuned for it: no emission rate, dwell time or threshold has been
+refitted. Whatever comes out is a lower bound on the approach with fitted
+parameters, and an honest measure of how far the defaults transfer.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
       - Inference: inference.md
       - Evaluation: evaluation.md
       - Limitations: limitations.md
+      - Real-data validation: real_data.md
   - Design records:
       - Multimodal architecture: MULTIMODAL_ARCHITECTURE.md
       - Research questions: RESEARCH_QUESTIONS.md

--- a/sensor_modeling/datasets/__init__.py
+++ b/sensor_modeling/datasets/__init__.py
@@ -1,0 +1,39 @@
+"""Adapters bringing public annotated datasets into the canonical model.
+
+Everything else in this package is validated on a simulator this project wrote.
+That establishes properties of the inference model, not of any real home. These
+adapters exist so the same pipeline can be run against data it did not generate,
+which is the only way to find out whether the architecture survives contact with
+reality.
+
+An adapter converts a published recording into :class:`Observation` values and a
+ground-truth series. It does not adjust, clean or reinterpret the data to suit
+the pipeline: where a dataset cannot answer a question the pipeline asks, the
+adapter reports that rather than inventing an answer.
+
+No dataset is redistributed here. Each adapter documents where to obtain the
+recording and under what terms.
+"""
+
+from .casas import (
+    CASAS_ACTIVITY_STATES,
+    ActivityInterval,
+    CasasReadError,
+    CasasRecording,
+    casas_sensor_specs,
+    read_casas,
+    truth_series,
+)
+from .evaluate import DatasetEvaluation, evaluate_recording
+
+__all__ = [
+    "ActivityInterval",
+    "DatasetEvaluation",
+    "evaluate_recording",
+    "CASAS_ACTIVITY_STATES",
+    "CasasReadError",
+    "CasasRecording",
+    "casas_sensor_specs",
+    "read_casas",
+    "truth_series",
+]

--- a/sensor_modeling/datasets/casas.py
+++ b/sensor_modeling/datasets/casas.py
@@ -1,0 +1,442 @@
+"""Reading CASAS smart-home recordings into canonical observations.
+
+The CASAS project at Washington State University publishes annotated recordings
+from instrumented single-resident apartments. Each line of a raw recording is
+one sensor report::
+
+    2010-11-04 00:03:50.209589	M003	ON
+    2010-11-04 00:15:08.984841	T002	21.5
+    2010-11-04 05:40:51.303739	M004	ON	Sleeping	end
+
+The trailing columns appear only where an annotator marked an activity starting
+or ending, so labels arrive as sparse boundary markers rather than as a value on
+every row. Long stretches carry no label at all, and this module leaves them
+unlabelled instead of filling them in.
+
+Obtaining the data
+------------------
+Recordings are available from the CASAS project at
+``https://casas.wsu.edu/datasets/``, under the terms stated there. Nothing is
+redistributed with this package. Point :func:`read_casas` at a downloaded file.
+
+What this adapter will not do
+-----------------------------
+Three things a convenience reader might do silently, and why this one refuses.
+
+**It will not guess a timezone.** CASAS timestamps are local wall-clock with no
+offset. Reading them as UTC displaces every event by hours and quietly ruins any
+daily-rhythm analysis, and the pipeline requires aware instants regardless. The
+caller must say which zone the apartment was in.
+
+**It will not invent labels for unlabelled time.** Much of a typical recording
+carries no annotation. :func:`truth_series` returns ``None`` there, and the
+evaluation metrics skip those positions rather than scoring a guess.
+
+**It will not pretend the ontology matches.** CASAS activity vocabularies differ
+between apartments and do not correspond one-to-one with this package's
+behavioural states. Unmapped labels are reported on the recording rather than
+collapsed into ``UNKNOWN``, so a reader can see how much annotation was
+discarded.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Iterator, Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, tzinfo
+from pathlib import Path
+
+from ..observations import (
+    Modality,
+    Observation,
+    ObservationKind,
+    SensorRegistry,
+    SensorSpec,
+    Unit,
+)
+from ..states import BehaviouralState
+
+logger = logging.getLogger(__name__)
+
+
+class CasasReadError(ValueError):
+    """A recording could not be read as CASAS data."""
+
+
+#: How a sensor identifier's prefix maps onto the canonical model.
+#:
+#: CASAS names sensors by role: ``M`` motion, ``D`` door, ``T`` temperature,
+#: ``I`` item, ``L`` light, ``P`` power, ``AD`` analogue. Only prefixes with an
+#: unambiguous canonical meaning are mapped. The rest are reported as unmapped
+#: rather than forced into ``Modality.OTHER``, where they would contribute
+#: evidence nobody had reasoned about.
+SENSOR_PREFIXES: Mapping[str, tuple[Modality, ObservationKind, Unit]] = {
+    "M": (Modality.MOTION, ObservationKind.EVENT, Unit.NONE),
+    "D": (Modality.DOOR, ObservationKind.EVENT, Unit.NONE),
+    "T": (Modality.ENVIRONMENTAL, ObservationKind.SAMPLE, Unit.CELSIUS),
+}
+
+#: Sensor values that count as an activation for an event-kind sensor.
+ACTIVATION_VALUES = frozenset({"ON", "OPEN", "PRESENT", "START"})
+
+#: Values that close an activation. Counted, not emitted.
+DEACTIVATION_VALUES = frozenset({"OFF", "CLOSE", "ABSENT", "END"})
+
+#: CASAS activity labels mapped onto this package's behavioural states.
+#:
+#: The correspondence is imperfect, and the imperfections matter:
+#:
+#: - ``Eating`` maps to ``HOME_ACTIVE`` rather than ``KITCHEN_ACTIVITY``. The
+#:   ontology's kitchen state means being active in the kitchen, and meals are
+#:   frequently eaten elsewhere; mapping it to the kitchen would manufacture
+#:   agreement with an inference that keys on kitchen sensors.
+#: - ``Bed_to_Toilet`` maps to ``BATHROOM_ACTIVITY`` for the destination, losing
+#:   the fact that it is a night-time transition out of bed.
+#: - ``Respirate`` has no counterpart and is deliberately absent, so it is
+#:   reported unmapped rather than scored.
+#:
+#: Pass a different mapping to :func:`read_casas` to make other choices. The
+#: point is that the choice is visible rather than buried.
+CASAS_ACTIVITY_STATES: Mapping[str, BehaviouralState] = {
+    "Sleeping": BehaviouralState.SLEEPING,
+    "Bed_to_Toilet": BehaviouralState.BATHROOM_ACTIVITY,
+    "Meal_Preparation": BehaviouralState.KITCHEN_ACTIVITY,
+    "Wash_Dishes": BehaviouralState.KITCHEN_ACTIVITY,
+    "Housekeeping": BehaviouralState.HOME_ACTIVE,
+    "Work": BehaviouralState.HOME_ACTIVE,
+    "Eating": BehaviouralState.HOME_ACTIVE,
+    "Enter_Home": BehaviouralState.HOME_ACTIVE,
+    "Relax": BehaviouralState.HOME_INACTIVE,
+    "Leave_Home": BehaviouralState.AWAY,
+}
+
+
+@dataclass(frozen=True)
+class ActivityInterval:
+    """One annotated activity, from its begin marker to its end marker."""
+
+    label: str
+    start: datetime
+    end: datetime
+    state: BehaviouralState | None
+
+    def __post_init__(self) -> None:
+        """Reject an interval that ends before it starts."""
+        if self.end < self.start:
+            raise CasasReadError(
+                f"activity {self.label!r} ends at {self.end} before it starts "
+                f"at {self.start}"
+            )
+
+    def contains(self, moment: datetime) -> bool:
+        """Whether *moment* falls inside the interval, end-exclusive."""
+        return self.start <= moment < self.end
+
+
+@dataclass(frozen=True)
+class CasasRecording:
+    """A parsed recording, together with what could not be represented.
+
+    Attributes
+    ----------
+    registry
+        Sensors seen in the file, described in canonical terms.
+    observations
+        Every reading that mapped onto a canonical sensor, ordered in time.
+    activities
+        Annotated intervals, including those whose label did not map.
+    unmapped_sensors
+        Sensor identifiers whose prefix has no canonical meaning. Their readings
+        do not appear in *observations*.
+    unmapped_activities
+        Activity labels with no counterpart in the state ontology, and how often
+        each appeared. Those intervals are present but carry ``state=None``.
+    deactivations
+        Count of OFF-style readings, which are not emitted. See
+        :func:`read_casas`.
+    unparsed_lines
+        Lines that were not readable as sensor reports.
+    """
+
+    registry: SensorRegistry
+    observations: tuple[Observation, ...]
+    activities: tuple[ActivityInterval, ...]
+    unmapped_sensors: frozenset[str] = frozenset()
+    unmapped_activities: Mapping[str, int] = field(default_factory=dict)
+    deactivations: int = 0
+    unparsed_lines: int = 0
+
+    @property
+    def labelled_fraction(self) -> float:
+        """Fraction of the recorded span covered by a mapped activity.
+
+        The number to check before believing any accuracy computed against this
+        recording, because it says how much of the time was actually scored.
+        """
+        if not self.observations:
+            return 0.0
+        span = (
+            self.observations[-1].timestamp - self.observations[0].timestamp
+        ).total_seconds()
+        if span <= 0:
+            return 0.0
+        covered = sum(
+            (interval.end - interval.start).total_seconds()
+            for interval in self.activities
+            if interval.state is not None
+        )
+        return min(covered / span, 1.0)
+
+    def summary(self) -> dict[str, object]:
+        """Return what was read and what was discarded."""
+        return {
+            "observations": len(self.observations),
+            "sensors": len(self.registry.sensor_ids()),
+            "activities": len(self.activities),
+            "labelled_fraction": self.labelled_fraction,
+            "unmapped_sensors": sorted(self.unmapped_sensors),
+            "unmapped_activities": dict(self.unmapped_activities),
+            "deactivations_ignored": self.deactivations,
+            "unparsed_lines": self.unparsed_lines,
+        }
+
+
+def _sensor_prefix(sensor_id: str) -> str:
+    """Return the leading alphabetic run of a CASAS sensor identifier."""
+    prefix = ""
+    for character in sensor_id:
+        if not character.isalpha():
+            break
+        prefix += character
+    return prefix.upper()
+
+
+def casas_sensor_specs(
+    sensor_ids: Iterable[str],
+    *,
+    rooms: Mapping[str, str] | None = None,
+) -> tuple[list[SensorSpec], frozenset[str]]:
+    """Describe CASAS sensors canonically, and report those that cannot be.
+
+    The raw files carry no machine-readable sensor-to-room map, so *rooms* is
+    optional and unset by default. Room drives the occupancy layer, and
+    inferring it from sensor numbering would be fabrication.
+    """
+    room_map = dict(rooms or {})
+    specs: list[SensorSpec] = []
+    unmapped: set[str] = set()
+
+    for sensor_id in sorted(set(sensor_ids)):
+        mapping = SENSOR_PREFIXES.get(_sensor_prefix(sensor_id))
+        if mapping is None:
+            unmapped.add(sensor_id)
+            continue
+        modality, kind, unit = mapping
+        specs.append(
+            SensorSpec(
+                sensor_id=sensor_id,
+                modality=modality,
+                kind=kind,
+                unit=unit,
+                room=room_map.get(sensor_id),
+                attributable=False,
+                description=f"CASAS sensor {sensor_id}",
+            )
+        )
+    return specs, frozenset(unmapped)
+
+
+ParsedLine = tuple[datetime, str, str, "str | None", "str | None"]
+
+
+def _parse_line(line: str) -> ParsedLine | None:
+    """Split one raw line, or return ``None`` if it is not a sensor report."""
+    parts = line.split()
+    if len(parts) < 4:
+        return None
+
+    stamp = f"{parts[0]} {parts[1]}"
+    for pattern in ("%Y-%m-%d %H:%M:%S.%f", "%Y-%m-%d %H:%M:%S"):
+        try:
+            moment = datetime.strptime(stamp, pattern)
+            break
+        except ValueError:
+            continue
+    else:
+        return None
+
+    label = parts[4] if len(parts) > 4 else None
+    marker = parts[5].lower() if len(parts) > 5 else None
+    return moment, parts[2], parts[3], label, marker
+
+
+def read_casas(
+    source: Path | str | Iterable[str],
+    *,
+    timezone: tzinfo,
+    activity_states: Mapping[str, BehaviouralState] | None = None,
+    rooms: Mapping[str, str] | None = None,
+) -> CasasRecording:
+    """Read a CASAS recording into canonical observations and annotations.
+
+    Parameters
+    ----------
+    source
+        Path to a raw recording, or an iterable of its lines.
+    timezone
+        The zone the apartment was in. Required, because CASAS timestamps are
+        naive local wall-clock and there is no correct default.
+    activity_states
+        Overrides :data:`CASAS_ACTIVITY_STATES`.
+    rooms
+        Optional sensor-to-room assignment, if one is known for the apartment.
+
+    Notes
+    -----
+    Motion and door sensors report ON/OFF and OPEN/CLOSE pairs. Only the
+    activating half becomes an observation, because the pipeline models these as
+    event-kind sensors whose *rate* carries the information, and admitting the
+    closing half would double every count. The discarded readings are counted in
+    :attr:`CasasRecording.deactivations` rather than dropped silently, because
+    treating them as state-kind evidence instead is a legitimate alternative
+    this adapter does not take.
+    """
+    if timezone is None:  # pragma: no cover - defensive
+        raise CasasReadError("a timezone is required; CASAS timestamps are naive")
+
+    lines: Iterator[str]
+    if isinstance(source, (str, Path)):
+        path = Path(source)
+        if not path.exists():
+            raise CasasReadError(f"no CASAS recording at {path}")
+        lines = iter(path.read_text(encoding="utf-8", errors="replace").splitlines())
+    else:
+        lines = iter(source)
+
+    states = dict(
+        activity_states if activity_states is not None else CASAS_ACTIVITY_STATES
+    )
+
+    parsed: list[ParsedLine] = []
+    unparsed = 0
+    for raw in lines:
+        if not raw.strip():
+            continue
+        record = _parse_line(raw)
+        if record is None:
+            unparsed += 1
+            continue
+        parsed.append(record)
+
+    if not parsed:
+        raise CasasReadError("no readable sensor reports found")
+
+    specs, unmapped_sensors = casas_sensor_specs(
+        (sensor_id for _, sensor_id, _, _, _ in parsed), rooms=rooms
+    )
+    registry = SensorRegistry.from_specs(specs)
+    by_id = {spec.sensor_id: spec for spec in specs}
+
+    observations: list[Observation] = []
+    deactivations = 0
+    open_activities: dict[str, datetime] = {}
+    activities: list[ActivityInterval] = []
+    unmapped_activities: dict[str, int] = {}
+
+    for moment, sensor_id, value, label, marker in parsed:
+        aware = moment.replace(tzinfo=timezone)
+
+        if label is not None and marker in {"begin", "end"}:
+            if marker == "begin":
+                open_activities[label] = aware
+            else:
+                start = open_activities.pop(label, None)
+                if start is None:
+                    # An end without a begin has no duration to record.
+                    logger.debug("activity %r ended without beginning", label)
+                else:
+                    state = states.get(label)
+                    if state is None:
+                        unmapped_activities[label] = (
+                            unmapped_activities.get(label, 0) + 1
+                        )
+                    activities.append(
+                        ActivityInterval(
+                            label=label, start=start, end=aware, state=state
+                        )
+                    )
+
+        spec = by_id.get(sensor_id)
+        if spec is None:
+            continue
+
+        upper = value.upper()
+        if spec.kind is ObservationKind.EVENT:
+            if upper in DEACTIVATION_VALUES:
+                deactivations += 1
+                continue
+            if upper not in ACTIVATION_VALUES:
+                continue
+            numeric = 1.0
+        else:
+            try:
+                numeric = float(value)
+            except ValueError:
+                continue
+
+        observations.append(
+            Observation(
+                timestamp=aware,
+                sensor_id=sensor_id,
+                modality=spec.modality,
+                kind=spec.kind,
+                value=numeric,
+                unit=spec.unit,
+                source="casas",
+            )
+        )
+
+    observations.sort(key=lambda observation: observation.timestamp)
+    activities.sort(key=lambda interval: interval.start)
+
+    if open_activities:
+        logger.warning(
+            "%d activity annotation(s) never ended and were dropped: %s",
+            len(open_activities),
+            sorted(open_activities),
+        )
+
+    return CasasRecording(
+        registry=registry,
+        observations=tuple(observations),
+        activities=tuple(activities),
+        unmapped_sensors=unmapped_sensors,
+        unmapped_activities=unmapped_activities,
+        deactivations=deactivations,
+        unparsed_lines=unparsed,
+    )
+
+
+def truth_series(
+    activities: Sequence[ActivityInterval],
+    moments: Sequence[datetime],
+) -> list[BehaviouralState | None]:
+    """Return the annotated state at each moment, ``None`` where unlabelled.
+
+    ``None`` is the honest answer for the large unannotated stretches of a real
+    recording, and the evaluation metrics skip those positions rather than
+    scoring a guess against them. Where annotations overlap, the one that
+    started most recently wins.
+    """
+    ordered = sorted(activities, key=lambda interval: interval.start)
+    series: list[BehaviouralState | None] = []
+    for moment in moments:
+        found: BehaviouralState | None = None
+        for interval in ordered:
+            if interval.start > moment:
+                break
+            if interval.contains(moment):
+                found = interval.state
+        series.append(found)
+    return series

--- a/sensor_modeling/datasets/evaluate.py
+++ b/sensor_modeling/datasets/evaluate.py
@@ -1,0 +1,127 @@
+"""Running the standard pipeline against a real recording.
+
+Everything else in this package is scored on a simulator this project wrote.
+This module runs the same inference, unchanged, over data the project did not
+generate, which is the only way to find out whether the architecture survives
+contact with reality.
+
+It deliberately does not tune anything. No emission rate, dwell time or
+threshold is refitted to the dataset. A result produced here is therefore a
+lower bound on what the approach could do with fitted parameters, and an honest
+measure of how far the declared defaults transfer.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any
+
+from ..evaluation.metrics import StateMetrics, state_metrics
+from ..online import BehaviouralSensingPipeline, PipelineConfig
+from .casas import CasasRecording, truth_series
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DatasetEvaluation:
+    """What the pipeline achieved on a real recording, and on how much of it.
+
+    Attributes
+    ----------
+    metrics
+        State-inference quality over the positions that carried a label.
+    steps
+        Pipeline steps produced.
+    scored
+        Positions that had a mapped annotation and were therefore scored.
+    labelled_fraction
+        Fraction of the recording's span covered by mapped annotation.
+    recording
+        What the adapter discarded on the way in.
+    """
+
+    metrics: StateMetrics
+    steps: int
+    scored: int
+    labelled_fraction: float
+    recording: dict[str, Any]
+
+    @property
+    def scored_fraction(self) -> float:
+        """Share of pipeline steps that could be scored at all."""
+        return self.scored / self.steps if self.steps else 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a serialisable form, coverage alongside the scores.
+
+        Coverage travels with the metrics deliberately. A balanced accuracy
+        computed over a tenth of a recording is a different claim from one
+        computed over most of it, and separating the two invites the reader to
+        forget the difference.
+        """
+        return {
+            "metrics": self.metrics.to_dict(),
+            "steps": self.steps,
+            "scored": self.scored,
+            "scored_fraction": self.scored_fraction,
+            "labelled_fraction": self.labelled_fraction,
+            "recording": self.recording,
+        }
+
+
+def evaluate_recording(
+    recording: CasasRecording,
+    *,
+    step: timedelta = timedelta(minutes=10),
+    config: PipelineConfig | None = None,
+) -> DatasetEvaluation:
+    """Run the standard pipeline over a recording and score it where labelled.
+
+    Parameters
+    ----------
+    recording
+        A parsed recording, from :func:`~sensor_modeling.datasets.read_casas`.
+    step
+        Inference step. Real recordings are far denser than the simulator's, so
+        a short step produces a great many mostly-unlabelled positions.
+    config
+        Pipeline configuration. The timezone is taken from the observations if
+        not supplied, since the recording already fixed it.
+
+    Raises
+    ------
+    ValueError
+        If the recording produced no observations, or if nothing in it carried
+        a mapped label. Returning a metric computed over nothing would look
+        like a result.
+    """
+    if not recording.observations:
+        raise ValueError("recording contains no usable observations")
+
+    tz = recording.observations[0].timestamp.tzinfo
+    settings = config or PipelineConfig(tz=tz, step=step)
+
+    pipeline = BehaviouralSensingPipeline(recording.registry, config=settings)
+    steps = pipeline.run(recording.observations)
+    steps.extend(pipeline.close(recording.observations[-1].timestamp))
+    if not steps:
+        raise ValueError("pipeline produced no steps for this recording")
+
+    truth = truth_series(recording.activities, [s.at for s in steps])
+    scored = sum(1 for label in truth if label is not None)
+    if scored == 0:
+        raise ValueError(
+            "no pipeline step fell inside a mapped annotation, so nothing can "
+            "be scored; check the activity mapping and the step size"
+        )
+
+    return DatasetEvaluation(
+        metrics=state_metrics(truth, [s.state for s in steps]),
+        steps=len(steps),
+        scored=scored,
+        labelled_fraction=recording.labelled_fraction,
+        recording=recording.summary(),
+    )

--- a/tests/test_casas_dataset.py
+++ b/tests/test_casas_dataset.py
@@ -13,9 +13,9 @@ import pytest
 
 from sensor_modeling.datasets import (
     ActivityInterval,
-    evaluate_recording,
     CasasReadError,
     casas_sensor_specs,
+    evaluate_recording,
     read_casas,
     truth_series,
 )

--- a/tests/test_casas_dataset.py
+++ b/tests/test_casas_dataset.py
@@ -1,0 +1,322 @@
+"""Tests for reading CASAS recordings into the canonical model.
+
+The adapter's job is to lose nothing quietly. Most of these tests are about what
+it refuses to do: guess a timezone, invent a label, or let a sensor it does not
+understand contribute evidence anyway.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from sensor_modeling.datasets import (
+    ActivityInterval,
+    evaluate_recording,
+    CasasReadError,
+    casas_sensor_specs,
+    read_casas,
+    truth_series,
+)
+from sensor_modeling.observations import Modality, ObservationKind
+from sensor_modeling.states import BehaviouralState
+
+UTC = timezone.utc
+LISBON = timezone(timedelta(hours=1))
+
+LINES = [
+    "2010-11-04 00:03:50.209589\tM003\tON",
+    "2010-11-04 00:03:57.399391\tM003\tOFF",
+    "2010-11-04 00:15:08.984841\tT002\t21.5",
+    "2010-11-04 01:00:00.000000\tM004\tON\tSleeping\tbegin",
+    "2010-11-04 05:40:51.303739\tM004\tON\tSleeping\tend",
+    "2010-11-04 06:00:00.000000\tL001\tON",
+    "2010-11-04 07:00:00.000000\tM002\tON\tRespirate\tbegin",
+    "2010-11-04 07:10:00.000000\tM002\tON\tRespirate\tend",
+]
+
+
+def at(hour: int, minute: int = 0, tz: timezone = UTC) -> datetime:
+    return datetime(2010, 11, 4, hour, minute, tzinfo=tz)
+
+
+class TestTimestamps:
+    def test_timestamps_are_placed_in_the_stated_zone(self) -> None:
+        """The zone is the caller's to supply, and it must actually be applied.
+
+        CASAS records naive local wall-clock. Reading it as UTC would displace
+        every event, which is invisible in aggregate counts and fatal to any
+        analysis of daily rhythm.
+        """
+        recording = read_casas(LINES, timezone=LISBON)
+
+        first = recording.observations[0]
+        assert first.timestamp.utcoffset() == timedelta(hours=1)
+        assert first.timestamp.hour == 0
+
+    def test_the_same_file_in_two_zones_gives_different_instants(self) -> None:
+        utc = read_casas(LINES, timezone=UTC).observations[0].timestamp
+        lisbon = read_casas(LINES, timezone=LISBON).observations[0].timestamp
+
+        assert utc != lisbon
+
+    def test_observations_come_back_in_time_order(self) -> None:
+        stamps = [o.timestamp for o in read_casas(LINES, timezone=UTC).observations]
+        assert stamps == sorted(stamps)
+
+
+class TestSensorMapping:
+    def test_a_sensor_kind_it_cannot_interpret_is_excluded_and_reported(self) -> None:
+        """An unrecognised sensor must not become evidence by default.
+
+        Mapping every unknown prefix to ``OTHER`` would let a light switch or a
+        power meter push the posterior around under a modality nobody had
+        reasoned about. Excluding it silently would be just as bad, so it is
+        excluded and named.
+        """
+        recording = read_casas(LINES, timezone=UTC)
+
+        assert "L001" in recording.unmapped_sensors
+        assert all(o.sensor_id != "L001" for o in recording.observations)
+
+    def test_prefixes_map_to_the_expected_modality_and_kind(self) -> None:
+        specs, _ = casas_sensor_specs(["M003", "D001", "T002"])
+        by_id = {spec.sensor_id: spec for spec in specs}
+
+        assert by_id["M003"].modality is Modality.MOTION
+        assert by_id["M003"].kind is ObservationKind.EVENT
+        assert by_id["D001"].modality is Modality.DOOR
+        assert by_id["T002"].modality is Modality.ENVIRONMENTAL
+        assert by_id["T002"].kind is ObservationKind.SAMPLE
+
+    def test_rooms_are_left_unset_unless_supplied(self) -> None:
+        """Room drives occupancy, and the raw files do not carry it."""
+        specs, _ = casas_sensor_specs(["M003"])
+        assert specs[0].room is None
+
+        specs, _ = casas_sensor_specs(["M003"], rooms={"M003": "kitchen"})
+        assert specs[0].room == "kitchen"
+
+
+class TestEventSemantics:
+    def test_closing_readings_are_counted_rather_than_emitted(self) -> None:
+        """Emitting OFF as well as ON would double every event rate.
+
+        The pipeline reads motion and door sensors as event-kind, where the rate
+        carries the information. Admitting both halves of each pair would inflate
+        every Poisson rate by a factor of two.
+        """
+        recording = read_casas(LINES, timezone=UTC)
+
+        assert recording.deactivations == 1
+        assert all(
+            o.value == 1.0 for o in recording.observations if o.sensor_id == "M003"
+        )
+        assert sum(1 for o in recording.observations if o.sensor_id == "M003") == 1
+
+    def test_sample_sensors_keep_their_numeric_value(self) -> None:
+        recording = read_casas(LINES, timezone=UTC)
+        temperature = [o for o in recording.observations if o.sensor_id == "T002"]
+
+        assert len(temperature) == 1
+        assert temperature[0].value == pytest.approx(21.5)
+
+
+class TestAnnotations:
+    def test_a_label_outside_the_ontology_is_reported_not_coerced(self) -> None:
+        """An unmapped label must not silently become UNKNOWN.
+
+        UNKNOWN is a claim the ontology makes about abstention. Reusing it for
+        "this dataset had a word we do not model" would confuse a scoring
+        convention with a gap in the mapping.
+        """
+        recording = read_casas(LINES, timezone=UTC)
+
+        assert recording.unmapped_activities == {"Respirate": 1}
+        respirate = [a for a in recording.activities if a.label == "Respirate"]
+        assert respirate and respirate[0].state is None
+
+    def test_a_mapped_label_becomes_an_interval_with_a_state(self) -> None:
+        recording = read_casas(LINES, timezone=UTC)
+        sleeping = [a for a in recording.activities if a.label == "Sleeping"]
+
+        assert len(sleeping) == 1
+        assert sleeping[0].state is BehaviouralState.SLEEPING
+        assert sleeping[0].start == at(1)
+
+    def test_an_end_without_a_begin_is_dropped(self) -> None:
+        """A dangling end marker has no duration and cannot be scored."""
+        recording = read_casas(
+            ["2010-11-04 05:00:00.0\tM004\tON\tSleeping\tend"], timezone=UTC
+        )
+        assert recording.activities == ()
+
+    def test_an_interval_cannot_end_before_it_starts(self) -> None:
+        with pytest.raises(CasasReadError, match="before it starts"):
+            ActivityInterval(label="Sleeping", start=at(5), end=at(1), state=None)
+
+    def test_the_activity_map_can_be_overridden(self) -> None:
+        recording = read_casas(
+            LINES,
+            timezone=UTC,
+            activity_states={"Respirate": BehaviouralState.HOME_INACTIVE},
+        )
+
+        assert "Respirate" not in recording.unmapped_activities
+        # Sleeping is no longer mapped under the replacement vocabulary.
+        assert "Sleeping" in recording.unmapped_activities
+
+
+class TestTruthSeries:
+    def test_unlabelled_time_is_none_rather_than_a_guess(self) -> None:
+        """Half a real recording is unannotated, and must not be scored.
+
+        ``state_metrics`` skips ``None``. Filling the gaps with a plausible
+        state would invent agreement or disagreement that no annotator recorded.
+        """
+        recording = read_casas(LINES, timezone=UTC)
+        series = truth_series(recording.activities, [at(0), at(3), at(9)])
+
+        assert series == [None, BehaviouralState.SLEEPING, None]
+
+    def test_an_unmapped_interval_yields_none(self) -> None:
+        recording = read_casas(LINES, timezone=UTC)
+        assert truth_series(recording.activities, [at(7, 5)]) == [None]
+
+    def test_intervals_are_end_exclusive(self) -> None:
+        interval = ActivityInterval(
+            label="Sleeping", start=at(1), end=at(5), state=BehaviouralState.SLEEPING
+        )
+        assert interval.contains(at(1))
+        assert not interval.contains(at(5))
+
+
+class TestRobustness:
+    def test_unreadable_lines_are_counted(self) -> None:
+        recording = read_casas([*LINES, "not a sensor report"], timezone=UTC)
+        assert recording.unparsed_lines == 1
+
+    def test_a_file_with_nothing_readable_is_an_error(self) -> None:
+        with pytest.raises(CasasReadError, match="no readable sensor reports"):
+            read_casas(["nonsense", "more nonsense"], timezone=UTC)
+
+    def test_a_missing_file_is_an_error(self) -> None:
+        with pytest.raises(CasasReadError, match="no CASAS recording"):
+            read_casas("does/not/exist.txt", timezone=UTC)
+
+    def test_seconds_without_fractions_are_accepted(self) -> None:
+        recording = read_casas(["2010-11-04 00:03:50\tM003\tON"], timezone=UTC)
+        assert len(recording.observations) == 1
+
+    def test_labelled_fraction_reports_how_much_was_scored(self) -> None:
+        """Accuracy over a recording means little without knowing the coverage."""
+        recording = read_casas(LINES, timezone=UTC)
+
+        assert 0.0 < recording.labelled_fraction < 1.0
+
+    def test_the_summary_names_everything_discarded(self) -> None:
+        summary = read_casas(LINES, timezone=UTC).summary()
+
+        assert summary["unmapped_sensors"] == ["L001"]
+        assert summary["unmapped_activities"] == {"Respirate": 1}
+        assert summary["deactivations_ignored"] == 1
+
+
+def _realistic_day() -> list[str]:
+    """A day in CASAS format with plausible event density per activity.
+
+    Density is what distinguishes the states: a sleeping resident triggers
+    bedroom motion a handful of times a night, a cooking one triggers kitchen
+    motion every couple of minutes. A fixture with uniform density would make
+    the states indistinguishable and the test meaningless.
+    """
+    import random
+
+    rng = random.Random(11)
+    start = datetime(2010, 11, 4, 0, 0)
+    lines: list[str] = []
+
+    def stamp(moment: datetime) -> str:
+        return moment.strftime("%Y-%m-%d %H:%M:%S.%f")
+
+    def burst(sensor: str, begin: datetime, end: datetime, lo: int, hi: int) -> None:
+        moment = begin
+        while moment < end:
+            moment += timedelta(minutes=rng.randint(lo, hi))
+            if moment < end:
+                lines.append(f"{stamp(moment)}\t{sensor}\tON")
+
+    seven = start + timedelta(hours=7)
+    lines.append(f"{stamp(start)}\tM004\tON\tSleeping\tbegin")
+    burst("M004", start, seven, 40, 110)
+    lines.append(f"{stamp(seven)}\tM004\tON\tSleeping\tend")
+
+    kitchen_from = start + timedelta(hours=7, minutes=5)
+    kitchen_to = start + timedelta(hours=7, minutes=45)
+    lines.append(f"{stamp(kitchen_from)}\tM001\tON\tMeal_Preparation\tbegin")
+    burst("M001", kitchen_from, kitchen_to, 1, 3)
+    lines.append(f"{stamp(kitchen_to)}\tM001\tON\tMeal_Preparation\tend")
+
+    relax_from = start + timedelta(hours=8)
+    relax_to = start + timedelta(hours=11)
+    lines.append(f"{stamp(relax_from)}\tM002\tON\tRelax\tbegin")
+    burst("M002", relax_from, relax_to, 8, 20)
+    lines.append(f"{stamp(relax_to)}\tM002\tON\tRelax\tend")
+
+    lines.sort()
+    return lines
+
+
+ROOMS = {"M004": "bedroom", "M001": "kitchen", "M002": "living", "M003": "bathroom"}
+
+
+class TestPipelineIntegration:
+    """The adapter feeding the unmodified pipeline.
+
+    These tests establish that a CASAS-shaped recording reaches the inference
+    layers intact and is scored correctly. They are **not** real-data
+    validation: the fixture is synthesised in CASAS format by this repository,
+    so it says nothing about how the approach performs on an actual apartment.
+    That requires a downloaded recording, which is not redistributed here.
+    """
+
+    def test_a_recording_runs_through_the_pipeline_and_is_scored(self) -> None:
+        recording = read_casas(_realistic_day(), timezone=UTC, rooms=ROOMS)
+        result = evaluate_recording(recording, step=timedelta(minutes=10))
+
+        assert result.steps > 0
+        assert 0 < result.scored <= result.steps
+        assert 0.0 <= result.metrics.balanced_accuracy <= 1.0
+
+    def test_declared_defaults_separate_the_states_without_tuning(self) -> None:
+        """Nothing is refitted to the dataset, so this measures transfer.
+
+        If the emission defaults only worked on the simulator that produced
+        them, a differently shaped recording would score near chance.
+        """
+        recording = read_casas(_realistic_day(), timezone=UTC, rooms=ROOMS)
+        result = evaluate_recording(recording, step=timedelta(minutes=10))
+
+        assert result.metrics.balanced_accuracy > 0.5
+
+    def test_coverage_is_reported_beside_the_score(self) -> None:
+        """A score without its coverage invites reading it as the whole day."""
+        recording = read_casas(_realistic_day(), timezone=UTC, rooms=ROOMS)
+        payload = evaluate_recording(recording, step=timedelta(minutes=10)).to_dict()
+
+        assert "scored_fraction" in payload
+        assert "labelled_fraction" in payload
+        assert payload["scored"] < payload["steps"]
+
+    def test_a_recording_with_no_mapped_label_refuses_to_score(self) -> None:
+        """Metrics over an empty sample would look like a result."""
+        lines = [
+            "2010-11-04 00:00:00.0\tM001\tON\tRespirate\tbegin",
+            "2010-11-04 00:30:00.0\tM001\tON",
+            "2010-11-04 01:00:00.0\tM001\tON\tRespirate\tend",
+        ]
+        recording = read_casas(lines, timezone=UTC, rooms=ROOMS)
+
+        with pytest.raises(ValueError, match="nothing can be scored"):
+            evaluate_recording(recording, step=timedelta(minutes=10))


### PR DESCRIPTION
Everything in the package is scored on the simulator this project wrote, which establishes properties of the inference model rather than of any home. This adds `sensor_modeling.datasets` so published annotated recordings can be run through the same pipeline unchanged.

The adapter is built around refusing convenient guesses. It will not infer a timezone, because CASAS timestamps are naive local wall-clock and reading them as UTC silently displaces every event. It will not label unannotated time, because much of a recording has none and the metrics skip `None` rather than scoring a guess. It will not admit sensors or activity labels it cannot map, because an unrecognised light switch entering as `OTHER` would move the posterior under a modality nobody reasoned about, and an unmapped label becoming `UNKNOWN` would confuse a vocabulary gap with an abstention. Each is reported instead.

`evaluate_recording` runs the unmodified pipeline, refits nothing, and reports coverage in the same structure as the metrics. It refuses to score a recording where nothing carried a mapped label.

26 tests. The integration test uses a CASAS-format fixture written here, not a real recording, and says so: it establishes the wiring is correct and that declared defaults separate states without tuning. Running against downloaded CASAS data is the outstanding work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `sensor_modeling.datasets` so published annotated CASAS recordings can be run through the pipeline unchanged, instead of everything being scored only on the project's own simulator. The adapter reports rather than guesses: no timezone is inferred, unannotated time is not labelled, and unmapped sensors or activities are named and discarded instead of coerced into the ontology.

**New Features**
- `read_casas` maps motion, door, and temperature sensors canonically, requires the apartment's timezone, and reports unmapped sensors and activity labels.
- `evaluate_recording` runs the unmodified pipeline, refits nothing, and reports scored and labelled coverage beside the metrics.
- Scoring is refused when no pipeline step falls inside a mapped annotation.
- Adds `docs/real_data.md`, which states that the integration test uses a CASAS-format fixture written by this repository, not a real recording.

<sup>Written for commit 141f9ee418d557f31990bb320da52382c6952644. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

