### PR TITLE
Freeze confirmatory scientific decision contract

### DIFF
--- a/papers/failure-aware-multimodal-behavioural-sensing/experiments/CONFIRMATORY_CONTRACT.md
+++ b/papers/failure-aware-multimodal-behavioural-sensing/experiments/CONFIRMATORY_CONTRACT.md
@@ -1,0 +1,108 @@
+# Confirmatory scientific contract
+
+**Status:** pre-specified, no confirmatory results examined.
+
+This file is the authoritative decision contract for the confirmatory simulation study in *Failure-Aware Multimodal Behavioural Sensing*. If provisional manuscript prose differs from this file or from `config.json`, the manuscript must be corrected to match this contract before reporting confirmatory results. The contract must not be changed in response to primary-result values.
+
+## Replication unit and seed independence
+
+The independent replication unit is one simulated household trajectory. Time points are not replications. Production household seeds are
+
+\[
+s_i = 10000 + 4i,\qquad i=0,\ldots,N-1.
+\]
+
+The stride of four is required because H3 attribution scenarios derive degradation streams at offsets `seed + 1`, `seed + 2`, and `seed + 3`. Sharded execution is permitted only when the merged seed union is exactly the frozen seed set, with no duplicates or omissions.
+
+The initial production size is \(N=200\). It may increase, without inspecting hypothesis direction or changing any analysis choice, only as needed to satisfy the pre-specified H2 Monte Carlo precision criterion, up to \(N=1000\).
+
+## H1 — graceful degradation
+
+H1 evaluates the pre-specified random-missingness rates 0%, 5%, 10%, 20%, and 40% on paired household trajectories. The 0% arm is the reference. Balanced accuracy, log loss, Brier score, calibration error, and abstention are reported at each rate, together with paired changes from the 0% reference and household-level uncertainty.
+
+H1 is descriptive about the degradation curve; no post-result breakpoint or subset of missingness rates may be selected as the primary H1 result.
+
+## H2 — reduced multimodal deployment
+
+H2 has **one primary non-inferiority contrast**:
+
+- reference: `all_modalities` (10 sensors);
+- reduced deployment: `radar_door_bed_wearable` (5 sensors);
+- primary metric: balanced accuracy;
+- estimand:
+
+\[
+D_{H2}=\operatorname{BA}_{\mathrm{full}}-\operatorname{BA}_{\mathrm{reduced}};
+\]
+
+- absolute non-inferiority margin: \(\Delta=0.02\);
+- confidence level: 95% household-paired bootstrap interval.
+
+The reduced configuration supports the primary H2 claim iff
+
+\[
+\boxed{U_{0.95}(D_{H2}) < 0.02,}
+\]
+
+where \(U_{0.95}\) is the upper endpoint of the two-sided 95% paired bootstrap interval. The inequality is strict. Failure to satisfy it is a negative H2 result, not a reason to select another sensor subset or change the margin.
+
+The other pre-specified sensor configurations remain secondary ablations. Log loss, Brier score, calibration error, and abstention are reported for safety/context, but they are not additional gates that can override the frozen balanced-accuracy decision rule. Failure robustness is addressed separately by H4.
+
+The H2 Monte Carlo precision gate is the configured `MCSE <= 0.002` criterion for paired balanced-accuracy gaps. Replication may be extended prospectively for precision only; the non-inferiority margin remains fixed.
+
+## H3 — attribution under contamination
+
+H3 reports occupancy-aware attribution effects separately for every pre-specified scenario. The primary interpretation is directional and scenario-specific: attribution should produce negligible change in `resident_alone` and improve state/probability performance when visitor or carer contamination is present.
+
+No pooled contaminated-scenario effect will be introduced after results are observed. Scenario-level balanced-accuracy gain, calibration gain, and visitor-detection performance are reported with household-level uncertainty.
+
+## H4 — failure-aware versus health-naive inference
+
+Both H4 arms receive **the same degraded observation record**: 30% random record loss plus the pre-specified `bed_pressure` dropout beginning on day 35 for 14 days.
+
+The treatment arm uses the normal failure-aware inference chain. The control arm preserves the same missing observations and health statuses but forces sensor-health reliability weights to one. It therefore tests the value of using health reliability in inference; it does **not** replace missing observations with zeros and does **not** treat missing evidence as observed silence.
+
+For every metric, the frozen estimand is
+
+\[
+M_{\mathrm{failure\ aware}}-M_{\mathrm{health\ naive}}.
+\]
+
+The sign must be interpreted according to the metric: positive is favourable for balanced accuracy, while negative is favourable for log loss, Brier score, and calibration error. Abstention is reported without assigning an intrinsically favourable direction.
+
+The current confirmatory H4 regime is random missingness plus a programmed sensor outage. The exploratory activity-correlated-loss experiment remains separate exploratory evidence and must not be described as part of the confirmatory H4 estimand.
+
+## H5 — non-additive sensor value
+
+For each pre-specified pair \((i,j)\), H5 estimates
+
+\[
+I_{ij} = \Delta_{ij}-(\Delta_i+\Delta_j)
+\]
+
+on paired household trajectories. All four interaction pairs are reported. No pair may be promoted or removed on the basis of the confirmatory values.
+
+## Pairing and uncertainty
+
+All paired contrasts are household-seed contrasts. Production shards are merged and deterministically sorted by seed before summaries are computed. A merged production artifact is valid only after exact seed-union and provenance checks pass.
+
+Uncertainty is calculated over households, never over individual time points. Bootstrap resampling is at household level with the pre-specified number of resamples.
+
+## Result-status and provenance rules
+
+A result may be labelled `confirmatory` only when all of the following hold:
+
+1. the exact frozen configuration is used;
+2. the exact frozen Git revision is used with a clean working tree;
+3. at least 200 independent household trajectories are present;
+4. the H2 Monte Carlo precision gate passes;
+5. all production shards agree on config SHA-256, Git revision, and numerical environment;
+6. the merged seed union exactly equals the frozen seed set.
+
+Otherwise the result is `pilot-or-incomplete` and cannot be used as a confirmatory manuscript result.
+
+## No post-result tuning
+
+After the scientific freeze, confirmatory values may not be used to alter hypotheses, margins, sensor configurations, metrics, seed rules, failure regimes, bootstrap rules, or the interpretation of metric direction. Any scientifically necessary change after primary-result access starts a new explicitly versioned experiment and leaves the original frozen result intact.
+
+All simulator outcomes remain simulator-derived and are not estimates of field performance.

--- a/papers/failure-aware-multimodal-behavioural-sensing/experiments/config.json
+++ b/papers/failure-aware-multimodal-behavioural-sensing/experiments/config.json
@@ -23,6 +23,15 @@
   "h1_missingness": {
     "rates": [0.0, 0.05, 0.10, 0.20, 0.40]
   },
+  "h2_primary_noninferiority": {
+    "reference_configuration": "all_modalities",
+    "reduced_configuration": "radar_door_bed_wearable",
+    "metric": "balanced_accuracy",
+    "contrast": "full_minus_subset",
+    "absolute_margin": 0.02,
+    "confidence_level": 0.95,
+    "decision_rule": "ci_high_below_margin"
+  },
   "h2_sensor_subsets": {
     "all_modalities": [
       "front_door",
@@ -85,7 +94,9 @@
     "missing_rate": 0.30,
     "sensor_dropout": "bed_pressure",
     "dropout_start_day": 35,
-    "dropout_days": 14
+    "dropout_days": 14,
+    "control": "same_degraded_observations_with_health_reliabilities_forced_to_one",
+    "contrast": "failure_aware_minus_health_naive"
   },
   "h5_interactions": [
     ["living_radar", "resident_beacon"],


### PR DESCRIPTION
Final pre-result scientific-definition pass before freezing the confirmatory simulation.

This PR does not contain or inspect confirmatory results. It removes the remaining degrees of freedom that would be unsafe to decide after N=200 values exist.

Changes:
- adds one named H2 primary non-inferiority contrast: `radar_door_bed_wearable` (5 sensors) versus `all_modalities` (10 sensors);
- freezes the H2 balanced-accuracy estimand as `BA_full - BA_reduced`, absolute margin 0.02, and decision rule `upper endpoint of the two-sided 95% paired bootstrap CI < 0.02`;
- keeps all other H2 subsets as secondary ablations, so another configuration cannot be selected after seeing results;
- records the exact H4 control semantics: both arms receive the same degraded observations; the control only forces sensor-health reliabilities to one and does not impute missing records as silence;
- explicitly separates the confirmatory H4 random-loss + programmed-dropout regime from the exploratory activity-correlated-loss demonstration;
- adds `CONFIRMATORY_CONTRACT.md` as the authoritative pre-result decision contract, including replication unit, seed independence, H1-H5 estimands, uncertainty, provenance, sharding and no-post-result-tuning rules.

The executable production design remains 70 days, N>=200, N<=1000, seed stride 4, the existing sensor subsets/scenarios/interactions, and MCSE <= 0.002. No confirmatory numbers are generated or committed here.

The manuscript currently contains two older loose phrases (`equivalence` without a margin, and H4 as if missing evidence were treated as observed silence). The new contract explicitly states that manuscript prose must be reconciled to the frozen contract before confirmatory results are reported; those older sentences do not define the experiment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Freezes the pre-result scientific decision contract for the confirmatory simulation so hypotheses, margins, and decision rules can no longer be changed after N=200 values exist. No confirmatory results are generated or inspected in this PR.

- Adds `CONFIRMATORY_CONTRACT.md` as the authoritative pre-result contract covering H1–H5 estimands, replication and seed rules, provenance checks, sharding, and no-post-result-tuning restrictions.
- Locks H2 to one primary non-inferiority contrast: `radar_door_bed_wearable` (5 sensors) vs `all_modalities` (10 sensors), with paired balanced-accuracy estimand, absolute margin 0.02, and decision rule `upper endpoint of the two-sided 95% paired bootstrap CI < 0.02`; remaining H2 subsets stay secondary ablations.
- Records the H4 control semantics: both arms receive the same degraded observations, the control only forces sensor-health reliabilities to one and does not treat missing records as silence.
- Separates the confirmatory H4 random-loss plus programmed-dropout regime from the exploratory activity-correlated-loss demonstration.
- Requires manuscript prose to be reconciled to the frozen contract before any confirmatory results are reported.
- Leaves the executable production design unchanged at 70 days, N≥200 up to N≤1000, seed stride 4, and MCSE ≤ 0.002.

<sup>Written for commit 73da1d36c16b3d3fe2646d23bdcdea0deb0d4c49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/87?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

