### PR TITLE
Format final paper production launcher

### DIFF
--- a/papers/failure-aware-multimodal-behavioural-sensing/experiments/run_production.py
+++ b/papers/failure-aware-multimodal-behavioural-sensing/experiments/run_production.py
@@ -23,7 +23,9 @@ HYPOTHESES = ("h1", "h2", "h3", "h4", "h5")
 
 def _load_runner() -> ModuleType:
     """Load the paper runner without turning the paper directory into a package."""
-    spec = importlib.util.spec_from_file_location("paper_confirmatory_runner", RUNNER_PATH)
+    spec = importlib.util.spec_from_file_location(
+        "paper_confirmatory_runner", RUNNER_PATH
+    )
     if spec is None or spec.loader is None:
         raise RuntimeError("could not load run_confirmatory.py")
     module = importlib.util.module_from_spec(spec)
@@ -76,7 +78,9 @@ def _run_shard(
     seeds = _shard_seeds(full_seeds, shard_index, shard_count)
     provenance = runner._git_provenance()
     if provenance["commit"] == "unknown" or provenance["dirty"] is not False:
-        raise RuntimeError(f"production shard requires clean Git provenance: {provenance}")
+        raise RuntimeError(
+            f"production shard requires clean Git provenance: {provenance}"
+        )
 
     step = runner.timedelta(minutes=int(config["household"]["step_minutes"]))
     raw = {
@@ -192,7 +196,8 @@ def _merge_shards(
         "shard_count": shard_count,
         "results": results,
         "interpretation_guardrail": (
-            "All outcomes are simulator-derived and are not estimates of field performance."
+            "All outcomes are simulator-derived and are not estimates of field "
+            "performance."
         ),
     }
 


### PR DESCRIPTION
Formatter-only repair before the confirmatory experiment freeze.

The shared-branch CI after PR #87 showed a single failure: Black reformatted `papers/failure-aware-multimodal-behavioural-sensing/experiments/run_production.py`. Ruff, mypy, complexity, docs and package checks were otherwise clean at that point.

This PR applies only that Black-compatible formatting. It changes no experiment design, hypothesis, seed, margin, metric, failure regime, sharding logic, or scientific decision rule.

After this PR is merged and the merged `develop` revision is green, that exact executable revision can be pinned in the freeze manifest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies Black formatting to the final paper production launcher so the shared-branch CI passes before the confirmatory experiment freeze. The diff only changes line wrapping in `run_production.py`; no experiment design, seed, margin, metric, failure regime, sharding logic, or decision rule changes.

<sup>Written for commit a470f84400f3684e3685ccfc8ea5533bfa7a73a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

