### PR TITLE
Format frozen artifact validator

### DIFF
--- a/papers/failure-aware-multimodal-behavioural-sensing/experiments/validate_frozen_artifact.py
+++ b/papers/failure-aware-multimodal-behavioural-sensing/experiments/validate_frozen_artifact.py
@@ -98,17 +98,25 @@ def _validate_h2_decision(
     }
 
 
-def validate(manifest: Mapping[str, Any], artifact: Mapping[str, Any]) -> dict[str, Any]:
+def validate(
+    manifest: Mapping[str, Any], artifact: Mapping[str, Any]
+) -> dict[str, Any]:
     """Fail closed unless an artifact satisfies the frozen confirmatory contract."""
     frozen_revision = str(manifest["experiment_git_revision"])
     frozen_config_sha = str(manifest["frozen_files"]["config"]["sha256"])
 
     if artifact.get("status") != "confirmatory":
-        raise ValueError(f"artifact status is not confirmatory: {artifact.get('status')}")
+        raise ValueError(
+            f"artifact status is not confirmatory: {artifact.get('status')}"
+        )
     if "shard_count" not in artifact or int(artifact["shard_count"]) < 1:
-        raise ValueError("confirmatory artifact was not produced by the production shard merge")
+        raise ValueError(
+            "confirmatory artifact was not produced by the production shard merge"
+        )
     if artifact.get("git", {}).get("commit") != frozen_revision:
-        raise ValueError("artifact Git revision does not match the frozen experiment revision")
+        raise ValueError(
+            "artifact Git revision does not match the frozen experiment revision"
+        )
     if artifact.get("git", {}).get("dirty") is not False:
         raise ValueError("artifact Git provenance is not clean")
     if artifact.get("config_sha256") != frozen_config_sha:
@@ -119,7 +127,9 @@ def validate(manifest: Mapping[str, Any], artifact: Mapping[str, Any]) -> dict[s
         raise ValueError("artifact contains duplicate household seeds")
     expected = _expected_seeds(manifest, len(seeds))
     if seeds != expected:
-        raise ValueError("artifact seed sequence does not exactly match the frozen stride sequence")
+        raise ValueError(
+            "artifact seed sequence does not exactly match the frozen stride sequence"
+        )
 
     _assert_complete_coverage(artifact, set(expected))
 
@@ -134,7 +144,9 @@ def validate(manifest: Mapping[str, Any], artifact: Mapping[str, Any]) -> dict[s
 
     guardrail = str(artifact.get("interpretation_guardrail", "")).lower()
     if "simulator" not in guardrail or "field performance" not in guardrail:
-        raise ValueError("artifact is missing the simulator-only interpretation guardrail")
+        raise ValueError(
+            "artifact is missing the simulator-only interpretation guardrail"
+        )
 
     environment = artifact.get("environment", {})
     required_environment = manifest["reference_environment"]


### PR DESCRIPTION
Fixes the failed paper-only CI after PR #90 merged.

The failure was mechanical: `validate_frozen_artifact.py` passed `py_compile` and Ruff, but Black 23.9.1 reported that the file would be reformatted. The paper experiment smoke itself passed.

This PR applies only Black-compatible line wrapping to the validator. It does not change the freeze manifest, frozen experiment revision, config hash, seed formula, H2 decision rule, MCSE rule, artifact acceptance semantics, or any experiment code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the paper-only CI failure by reformatting `validate_frozen_artifact.py` to match Black 23.9.1. No experiment logic, freeze manifest, or artifact acceptance semantics changed.

<sup>Written for commit 1eefbabe336f8979fcad33820c45f38f43898e05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

