### PR TITLE
Pin production acceptance to dispatch revision

### DIFF
--- a/.github/workflows/paper-confirmatory-production.yml
+++ b/.github/workflows/paper-confirmatory-production.yml
@@ -18,8 +18,52 @@ env:
   PYTHON_VERSION: "3.11.16"
 
 jobs:
+  preflight:
+    name: validate dispatch
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Require manual develop dispatch
+        shell: bash
+        run: |
+          test "$GITHUB_EVENT_NAME" = "workflow_dispatch"
+          test "$GITHUB_REF" = "refs/heads/develop"
+
+      - name: Check out dispatch-time acceptance infrastructure
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          path: infra
+
+      - name: Verify dispatch-time freeze manifest
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          path = Path(
+              "infra/papers/failure-aware-multimodal-behavioural-sensing/"
+              "experiments/FREEZE_MANIFEST.json"
+          )
+          manifest = json.loads(path.read_text(encoding="utf-8"))
+          assert manifest["status"] == "frozen-pre-results"
+          assert manifest["experiment_git_revision"] == os.environ["FROZEN_REVISION"]
+          assert (
+              manifest["frozen_files"]["config"]["sha256"]
+              == os.environ["CONFIG_SHA256"]
+          )
+          assert manifest["replications"]["initial_n"] == int(
+              os.environ["REPLICATIONS"]
+          )
+          PY
+
   shard:
     name: shard ${{ matrix.shard }}
+    needs: preflight
     runs-on: ubuntu-24.04
     timeout-minutes: 240
     strategy:
@@ -185,10 +229,10 @@ jobs:
           fetch-depth: 0
           path: frozen
 
-      - name: Check out current acceptance infrastructure
+      - name: Check out dispatch-time acceptance infrastructure
         uses: actions/checkout@v7
         with:
-          ref: develop
+          ref: ${{ github.sha }}
           fetch-depth: 1
           path: infra
 


### PR DESCRIPTION
Fixes one reproducibility race in the manual confirmatory workflow before any production result is run.

The frozen scientific experiment remains unchanged at `bd5a9b10068b69fc75cc6f806904430633ce7408`.

The previous workflow checked out `develop` during the merge job to obtain `FREEZE_MANIFEST.json` and `validate_frozen_artifact.py`. Because 40 production shards can run for a long time, `develop` could move between dispatch and final merge, causing acceptance code to change underneath one run.

This PR:
- adds a preflight job requiring `workflow_dispatch` from `refs/heads/develop`;
- checks the dispatch-time manifest still points to the frozen experiment revision, config SHA and initial N=200;
- pins the acceptance-infrastructure checkout to `${{ github.sha }}` in the merge job rather than moving `develop`.

No experiment code, configuration, hypotheses, seeds, margins, bootstrap rules, environment pins, shard count or scientific acceptance criterion changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the manual production workflow to the dispatch revision so acceptance code cannot change underneath long-running shards.

Previously the merge job checked out `develop`, which could move between dispatch and final merge while 40 shards were running, causing acceptance checks to change mid-run. The merge job now checks out `${{ github.sha }}`, the exact revision dispatched.

- Adds a preflight job that rejects non-`workflow_dispatch` events and non-`develop` refs.
- Verifies the dispatch-time `FREEZE_MANIFEST.json` still matches the frozen experiment revision, config SHA, and initial N=200.
- Adds `needs: preflight` to the shard job.
- No experiment code, configuration, or scientific acceptance criteria change.

<sup>Written for commit dee9cd98d352be299d087a9b22bbc81fdcb20639. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/96?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

