### PR TITLE
Add v0.3 circadian and event-history primitives

### DIFF
--- a/sensor_modeling/fusion/history.py
+++ b/sensor_modeling/fusion/history.py
@@ -1,0 +1,102 @@
+"""Bounded, non-overlapping event evidence accumulation for v0.3.
+
+The current filter consumes each pipeline step independently.  Real-home
+feature ablations show that recent room-resolved event history contains signal
+that the instantaneous evidence does not.  Re-feeding already-used events on
+every step would be statistically wrong because the recursive posterior would
+count the same observation repeatedly.
+
+``EventEvidenceWindow`` therefore accumulates event observations until a fixed
+window closes and releases each event exactly once.  State and sample evidence
+are intentionally not accumulated here because their temporal semantics are
+different.  The buffer is serialisable so an edge restart cannot silently drop
+unconsumed evidence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+
+from ..observations.observation import Observation, require_aware
+
+
+@dataclass
+class EventEvidenceWindow:
+    """Accumulate event observations and release them exactly once per window."""
+
+    width: timedelta
+    _opened_at: datetime | None = None
+    _events: list[Observation] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.width <= timedelta(0):
+            raise ValueError("evidence window width must be positive")
+
+    @property
+    def opened_at(self) -> datetime | None:
+        """Start of the current window, if one has begun."""
+        return self._opened_at
+
+    @property
+    def pending(self) -> tuple[Observation, ...]:
+        """Unconsumed event evidence currently held in the window."""
+        return tuple(self._events)
+
+    def add(self, observation: Observation) -> None:
+        """Add one event observation to the current window."""
+        if not observation.is_event:
+            raise ValueError("EventEvidenceWindow accepts event observations only")
+        if self._opened_at is None:
+            self._opened_at = observation.timestamp
+        if observation.timestamp < self._opened_at:
+            raise ValueError("event precedes the current evidence window")
+        self._events.append(observation)
+        self._events.sort(key=lambda item: item.timestamp)
+
+    def ready(self, now: datetime) -> bool:
+        """Whether the current window is due to be consumed at *now*."""
+        moment = require_aware(now, "now")
+        return self._opened_at is not None and moment >= self._opened_at + self.width
+
+    def release(self, now: datetime, *, force: bool = False) -> tuple[Observation, ...]:
+        """Release pending events once and begin a new window at *now*.
+
+        Without ``force``, calling before the configured width has elapsed
+        returns an empty tuple and leaves the buffer unchanged.
+        """
+        moment = require_aware(now, "now")
+        if self._opened_at is None:
+            self._opened_at = moment
+            return ()
+        if not force and not self.ready(moment):
+            return ()
+        released = tuple(self._events)
+        self._events = []
+        self._opened_at = moment
+        return released
+
+    def reset(self) -> None:
+        """Discard pending evidence and clear the window clock."""
+        self._opened_at = None
+        self._events = []
+
+    def snapshot(self) -> dict[str, object]:
+        """Return JSON-serialisable restart state."""
+        return {
+            "width_seconds": self.width.total_seconds(),
+            "opened_at": self._opened_at.isoformat() if self._opened_at else None,
+            "events": [event.to_dict() for event in self._events],
+        }
+
+    @classmethod
+    def from_snapshot(cls, payload: dict[str, object]) -> "EventEvidenceWindow":
+        """Restore a window produced by :meth:`snapshot`."""
+        window = cls(timedelta(seconds=float(payload["width_seconds"])))
+        opened = payload.get("opened_at")
+        window._opened_at = require_aware(opened, "opened_at") if opened else None
+        raw_events = payload.get("events") or []
+        if not isinstance(raw_events, list):
+            raise TypeError("events must be a list")
+        window._events = [Observation.from_dict(item) for item in raw_events]
+        return window

--- a/sensor_modeling/states/circadian.py
+++ b/sensor_modeling/states/circadian.py
@@ -1,0 +1,102 @@
+"""Time-of-day transition weighting for behavioural state dynamics.
+
+The v0.2 ontology uses one homogeneous continuous-time generator.  This module
+adds a deliberately small extension for v0.3: keep each state's declared exit
+rate, but allow the *destination* probabilities of permitted transitions to
+change by local-time band.  The dwell-time semantics therefore remain intact;
+only where the chain prefers to go next changes with time of day.
+
+The module is parameter-free by default.  A schedule has to be supplied
+explicitly, which keeps development-data tuning separate from the mathematical
+mechanism and from the untouched external-validation cohort.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+
+import numpy as np
+
+from .markov import build_generator, transition_matrix
+from .ontology import BehaviouralState, StateOntology
+
+
+@dataclass(frozen=True)
+class CircadianBand:
+    """Destination-state multipliers active from ``start_hour`` local time.
+
+    Bands wrap over midnight.  ``start_hour`` is an integer in ``[0, 23]``.
+    A multiplier of one leaves a destination unchanged, values above one make
+    it more likely conditional on leaving the current state, and zero removes
+    that destination for the band when alternatives remain.
+    """
+
+    start_hour: int
+    destination_weights: Mapping[BehaviouralState, float] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.start_hour, int) or not 0 <= self.start_hour <= 23:
+            raise ValueError("start_hour must be an integer in [0, 23]")
+        for state, weight in self.destination_weights.items():
+            if not isinstance(state, BehaviouralState):
+                raise TypeError("circadian destination keys must be BehaviouralState values")
+            if not math.isfinite(weight) or weight < 0.0:
+                raise ValueError("circadian destination weights must be finite and non-negative")
+
+
+@dataclass(frozen=True)
+class CircadianSchedule:
+    """Piecewise-constant local-time transition preferences."""
+
+    bands: Sequence[CircadianBand]
+
+    def __post_init__(self) -> None:
+        ordered = tuple(sorted(self.bands, key=lambda band: band.start_hour))
+        if not ordered:
+            raise ValueError("a circadian schedule needs at least one band")
+        starts = [band.start_hour for band in ordered]
+        if len(starts) != len(set(starts)):
+            raise ValueError("circadian band start hours must be unique")
+        object.__setattr__(self, "bands", ordered)
+
+    def band_at(self, moment: datetime) -> CircadianBand:
+        """Return the band active at the timezone-aware *moment*."""
+        if moment.tzinfo is None or moment.utcoffset() is None:
+            raise ValueError("moment must be timezone-aware")
+        hour = moment.hour
+        candidates = [band for band in self.bands if band.start_hour <= hour]
+        return candidates[-1] if candidates else self.bands[-1]
+
+    def generator(self, ontology: StateOntology, moment: datetime) -> np.ndarray:
+        """Build the generator active at *moment* while preserving exit rates."""
+        band = self.band_at(moment)
+        size = ontology.size
+        rates = np.array(
+            [1.0 / ontology.dwell[state].total_seconds() for state in ontology.states],
+            dtype=float,
+        )
+        jumps = np.zeros((size, size), dtype=float)
+        for row, state in enumerate(ontology.states):
+            for target in ontology.jumps.get(state, ontology.states):
+                if target not in ontology.states or target is state:
+                    continue
+                weight = float(band.destination_weights.get(target, 1.0))
+                jumps[row, ontology.index(target)] = weight
+        return build_generator(rates, jumps)
+
+    def transition(
+        self, ontology: StateOntology, moment: datetime, elapsed: timedelta
+    ) -> np.ndarray:
+        """Return a row-stochastic transition matrix within the active band.
+
+        Callers that cross a band boundary should split the interval and
+        multiply the resulting matrices in chronological order.  The online
+        pipeline naturally advances on short fixed steps, so this primitive is
+        sufficient without embedding calendar logic into the CTMC algebra.
+        """
+        return transition_matrix(
+            self.generator(ontology, moment), elapsed.total_seconds()
+        )

--- a/tests/test_v03_primitives.py
+++ b/tests/test_v03_primitives.py
@@ -1,0 +1,116 @@
+"""Regression tests for the parameter-free v0.3 inference primitives."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import numpy as np
+import pytest
+
+from sensor_modeling.fusion.history import EventEvidenceWindow
+from sensor_modeling.observations import Modality, Observation, ObservationKind
+from sensor_modeling.states.circadian import CircadianBand, CircadianSchedule
+from sensor_modeling.states.ontology import BehaviouralState, StateOntology
+
+S = BehaviouralState
+T0 = datetime(2026, 1, 1, 2, 0, tzinfo=timezone.utc)
+
+
+def event(at: datetime, sensor_id: str = "motion") -> Observation:
+    return Observation(at, sensor_id, Modality.MOTION, ObservationKind.EVENT, 1.0)
+
+
+def test_circadian_generator_preserves_declared_exit_rates() -> None:
+    ontology = StateOntology()
+    schedule = CircadianSchedule(
+        [
+            CircadianBand(0, {S.SLEEPING: 5.0, S.HOME_ACTIVE: 0.5}),
+            CircadianBand(8, {S.SLEEPING: 0.2, S.HOME_ACTIVE: 3.0}),
+        ]
+    )
+    generator = schedule.generator(ontology, T0)
+    expected = np.array(
+        [-1.0 / ontology.dwell[state].total_seconds() for state in ontology.states]
+    )
+    assert np.allclose(np.diag(generator), expected)
+    assert np.allclose(generator.sum(axis=1), 0.0)
+
+
+def test_circadian_destination_weights_change_transition_preference() -> None:
+    ontology = StateOntology()
+    schedule = CircadianSchedule(
+        [
+            CircadianBand(0, {S.BED_AWAKE: 8.0, S.HOME_INACTIVE: 0.2}),
+            CircadianBand(12, {S.BED_AWAKE: 0.2, S.HOME_INACTIVE: 8.0}),
+        ]
+    )
+    night = schedule.transition(ontology, T0, timedelta(minutes=10))
+    noon = schedule.transition(
+        ontology, T0.replace(hour=12), timedelta(minutes=10)
+    )
+    row = ontology.index(S.HOME_ACTIVE)
+    bed = ontology.index(S.BED_AWAKE)
+    inactive = ontology.index(S.HOME_INACTIVE)
+    assert night[row, bed] > noon[row, bed]
+    assert noon[row, inactive] > night[row, inactive]
+
+
+def test_circadian_transition_is_row_stochastic() -> None:
+    ontology = StateOntology()
+    schedule = CircadianSchedule([CircadianBand(0, {S.SLEEPING: 2.0})])
+    matrix = schedule.transition(ontology, T0, timedelta(minutes=15))
+    assert np.allclose(matrix.sum(axis=1), 1.0)
+    assert matrix.min() >= 0.0
+
+
+def test_circadian_schedule_wraps_before_first_start_hour() -> None:
+    schedule = CircadianSchedule([CircadianBand(6), CircadianBand(18)])
+    assert schedule.band_at(T0).start_hour == 18
+
+
+def test_invalid_circadian_weights_are_rejected() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        CircadianBand(0, {S.SLEEPING: -1.0})
+
+
+def test_event_window_releases_each_event_once() -> None:
+    window = EventEvidenceWindow(timedelta(minutes=30))
+    first = event(T0)
+    second = event(T0 + timedelta(minutes=10))
+    window.add(first)
+    window.add(second)
+    assert window.release(T0 + timedelta(minutes=20)) == ()
+    released = window.release(T0 + timedelta(minutes=30))
+    assert released == (first, second)
+    assert window.pending == ()
+    assert window.release(T0 + timedelta(hours=1)) == ()
+
+
+def test_event_window_rejects_non_event_observations() -> None:
+    window = EventEvidenceWindow(timedelta(minutes=30))
+    sample = Observation(
+        T0,
+        "wearable",
+        Modality.WEARABLE_MOTION,
+        ObservationKind.SAMPLE,
+        0.5,
+    )
+    with pytest.raises(ValueError, match="event observations only"):
+        window.add(sample)
+
+
+def test_event_window_snapshot_round_trip_preserves_pending_evidence() -> None:
+    window = EventEvidenceWindow(timedelta(minutes=30))
+    window.add(event(T0))
+    window.add(event(T0 + timedelta(minutes=5), "door"))
+    restored = EventEvidenceWindow.from_snapshot(window.snapshot())
+    assert restored.width == window.width
+    assert restored.opened_at == window.opened_at
+    assert [item.to_dict() for item in restored.pending] == [
+        item.to_dict() for item in window.pending
+    ]
+
+
+def test_event_window_requires_positive_width() -> None:
+    with pytest.raises(ValueError, match="positive"):
+        EventEvidenceWindow(timedelta(0))


### PR DESCRIPTION
Closed after auditing concurrent work on `develop`.

PR #102 already implemented and development-tested the circadian prior, so the circadian primitives here would create a competing formulation rather than advance the model. PR #104 also established an important modelling objection to the recent-history idea: the recursive posterior already conditions on past observations, so injecting lagged copies as additional emission evidence can double-count the same information and recreate overconfidence.

Although `EventEvidenceWindow` releases each stored event only once, it changes the inference interval rather than providing a principled lag-conditioned emission model, and therefore does not solve that formulation problem. It should not be merged merely because classifier ablation found predictive signal in lags.

No code from this PR is required for the external-validation path. The untouched primary test cohort remains unscored.