### PR TITLE
Make circadian profile fitting reproducible

### DIFF
--- a/sensor_modeling/datasets/__init__.py
+++ b/sensor_modeling/datasets/__init__.py
@@ -25,6 +25,7 @@ from .casas import (
     truth_series,
 )
 from .casas_hh import HH_ACTIVITY_STATES, HH_LOCATIONS, hh_sensor_specs, read_casas_hh
+from .circadian import CircadianProfileFit, fit_circadian_profile
 from .evaluate import DatasetEvaluation, evaluate_recording
 from .rates import (
     RateReport,
@@ -36,6 +37,7 @@ from .rates import (
 
 __all__ = [
     "ActivityInterval",
+    "CircadianProfileFit",
     "DatasetEvaluation",
     "HH_ACTIVITY_STATES",
     "HH_LOCATIONS",
@@ -43,6 +45,7 @@ __all__ = [
     "read_casas_hh",
     "RateReport",
     "RateSample",
+    "fit_circadian_profile",
     "fit_emission_defaults",
     "measure_event_rates",
     "pooled_rate_report",

--- a/sensor_modeling/datasets/circadian.py
+++ b/sensor_modeling/datasets/circadian.py
@@ -1,0 +1,186 @@
+"""Fit circadian state-dynamics profiles from annotated development homes.
+
+The optional circadian prior in :class:`sensor_modeling.states.StateOntology`
+uses 24 positive stickiness multipliers per state.  This module turns labelled
+CASAS intervals into those multipliers in a deterministic, auditable way.
+
+For state ``z`` and local hour ``h`` the raw multiplier is the occupancy lift
+
+    P(Z=z | H=h) / P(Z=z).
+
+A small equivalent-duration prior shrinks sparse hour/state cells back toward
+one, and the final multipliers are clipped to a declared positive range.  The
+fit uses annotations only; it never evaluates the behavioural inference model
+and therefore cannot inspect external-test outcomes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+import hashlib
+import json
+import math
+
+from ..states import BehaviouralState, StateOntology
+from .casas import CasasRecording
+
+
+@dataclass(frozen=True)
+class CircadianProfileFit:
+    """A fitted per-state 24-hour stickiness profile and its provenance."""
+
+    profile: Mapping[BehaviouralState, tuple[float, ...]]
+    labelled_seconds: float
+    recordings: int
+    shrinkage_hours: float
+    minimum_multiplier: float
+    maximum_multiplier: float
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable JSON-serialisable representation."""
+        return {
+            "recordings": self.recordings,
+            "labelled_seconds": self.labelled_seconds,
+            "shrinkage_hours": self.shrinkage_hours,
+            "minimum_multiplier": self.minimum_multiplier,
+            "maximum_multiplier": self.maximum_multiplier,
+            "profile": {
+                state.value: [float(value) for value in values]
+                for state, values in sorted(
+                    self.profile.items(), key=lambda item: item[0].value
+                )
+            },
+        }
+
+    def sha256(self) -> str:
+        """Return the SHA-256 of the canonical serialised fit."""
+        payload = json.dumps(
+            self.to_dict(), sort_keys=True, separators=(",", ":"), allow_nan=False
+        ).encode("utf-8")
+        return hashlib.sha256(payload).hexdigest()
+
+
+def _split_hourly(start: datetime, end: datetime) -> list[tuple[int, float]]:
+    """Split ``[start, end)`` into local-hour pieces.
+
+    Returns ``(hour, seconds)`` pairs.  The timestamps are expected to already
+    be timezone-aware local wall-clock instants, as required by the CASAS
+    readers.  Splitting by the next wall-clock hour preserves the intended
+    circadian semantics across arbitrary interval lengths.
+    """
+    if end <= start:
+        return []
+    pieces: list[tuple[int, float]] = []
+    cursor = start
+    while cursor < end:
+        boundary = cursor.replace(minute=0, second=0, microsecond=0) + timedelta(
+            hours=1
+        )
+        stop = min(boundary, end)
+        seconds = (stop - cursor).total_seconds()
+        if seconds > 0.0:
+            pieces.append((cursor.hour, seconds))
+        cursor = stop
+    return pieces
+
+
+def fit_circadian_profile(
+    recordings: Sequence[CasasRecording],
+    *,
+    ontology: StateOntology | None = None,
+    shrinkage_hours: float = 2.0,
+    minimum_multiplier: float = 0.25,
+    maximum_multiplier: float = 4.0,
+) -> CircadianProfileFit:
+    """Fit 24-hour state stickiness multipliers from annotated recordings.
+
+    Parameters
+    ----------
+    recordings
+        Development-only annotated recordings.  Test homes must never be
+        passed here.
+    ontology
+        State set to fit.  Defaults to the standard seven-state ontology.
+    shrinkage_hours
+        Equivalent labelled time per hour used to shrink the conditional state
+        share toward the overall state share.  A value of zero disables
+        shrinkage.
+    minimum_multiplier, maximum_multiplier
+        Positive clipping bounds.  They prevent a sparse cell from making a
+        state effectively impossible to leave or implausibly sticky.
+
+    Notes
+    -----
+    The fit uses only mapped annotation durations.  Sensor observations and
+    inference predictions are not consulted.  A state absent from the
+    development annotations receives an all-ones profile rather than an
+    invented circadian pattern.
+    """
+    if not recordings:
+        raise ValueError("at least one recording is required")
+    if not math.isfinite(shrinkage_hours) or shrinkage_hours < 0.0:
+        raise ValueError("shrinkage_hours must be finite and non-negative")
+    if (
+        not math.isfinite(minimum_multiplier)
+        or not math.isfinite(maximum_multiplier)
+        or minimum_multiplier <= 0.0
+        or maximum_multiplier < minimum_multiplier
+    ):
+        raise ValueError("multiplier bounds must be positive and ordered")
+
+    states = ontology or StateOntology()
+    per_state_hour = {
+        state: [0.0 for _ in range(24)] for state in states.states
+    }
+    per_hour = [0.0 for _ in range(24)]
+    per_state = {state: 0.0 for state in states.states}
+    labelled_total = 0.0
+
+    for recording in recordings:
+        for interval in recording.activities:
+            state = interval.state
+            if state is None or state not in per_state_hour:
+                continue
+            for hour, seconds in _split_hourly(interval.start, interval.end):
+                per_state_hour[state][hour] += seconds
+                per_hour[hour] += seconds
+                per_state[state] += seconds
+                labelled_total += seconds
+
+    if labelled_total <= 0.0:
+        raise ValueError("recordings contain no mapped labelled duration")
+
+    shrinkage_seconds = shrinkage_hours * 3600.0
+    profile: dict[BehaviouralState, tuple[float, ...]] = {}
+    for state in states.states:
+        overall_share = per_state[state] / labelled_total
+        if overall_share <= 0.0:
+            profile[state] = tuple(1.0 for _ in range(24))
+            continue
+
+        values: list[float] = []
+        for hour in range(24):
+            hour_total = per_hour[hour]
+            if hour_total <= 0.0:
+                lift = 1.0
+            else:
+                conditional_share = (
+                    per_state_hour[state][hour]
+                    + shrinkage_seconds * overall_share
+                ) / (hour_total + shrinkage_seconds)
+                lift = conditional_share / overall_share
+            values.append(
+                min(max(float(lift), minimum_multiplier), maximum_multiplier)
+            )
+        profile[state] = tuple(values)
+
+    return CircadianProfileFit(
+        profile=profile,
+        labelled_seconds=labelled_total,
+        recordings=len(recordings),
+        shrinkage_hours=shrinkage_hours,
+        minimum_multiplier=minimum_multiplier,
+        maximum_multiplier=maximum_multiplier,
+    )

--- a/tests/test_circadian_fit.py
+++ b/tests/test_circadian_fit.py
@@ -1,0 +1,123 @@
+"""Tests for fitting circadian profiles from development-only annotations."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from sensor_modeling.datasets import (
+    ActivityInterval,
+    CasasRecording,
+    fit_circadian_profile,
+)
+from sensor_modeling.observations import Modality, SensorRegistry, SensorSpec
+from sensor_modeling.states import BehaviouralState as S
+
+UTC = timezone.utc
+
+
+def recording(*intervals: ActivityInterval) -> CasasRecording:
+    """Minimal annotated recording; the fitter deliberately ignores sensors."""
+    registry = SensorRegistry.from_specs(
+        [SensorSpec("M001", Modality.MOTION, room="bedroom")]
+    )
+    return CasasRecording(registry=registry, observations=(), activities=intervals)
+
+
+def interval(hour: int, hours: float, state: S) -> ActivityInterval:
+    start = datetime(2024, 1, 1, hour, tzinfo=UTC)
+    return ActivityInterval(state.value, start, start + timedelta(hours=hours), state)
+
+
+def test_sleeping_is_stickier_in_hours_where_it_is_overrepresented() -> None:
+    fit = fit_circadian_profile(
+        [
+            recording(
+                interval(0, 6, S.SLEEPING),
+                interval(8, 8, S.HOME_ACTIVE),
+                interval(16, 6, S.HOME_INACTIVE),
+            )
+        ],
+        shrinkage_hours=0.5,
+    )
+
+    sleeping = fit.profile[S.SLEEPING]
+    assert sleeping[2] > 1.0
+    assert sleeping[12] < 1.0
+
+
+def test_an_absent_state_gets_a_neutral_profile() -> None:
+    fit = fit_circadian_profile(
+        [recording(interval(9, 4, S.HOME_ACTIVE))], shrinkage_hours=1.0
+    )
+    assert fit.profile[S.BATHROOM_ACTIVITY] == pytest.approx(tuple([1.0] * 24))
+
+
+def test_intervals_are_split_across_hour_boundaries() -> None:
+    start = datetime(2024, 1, 1, 9, 30, tzinfo=UTC)
+    spans = ActivityInterval(
+        "sleep", start, start + timedelta(hours=2), S.SLEEPING
+    )
+    fit = fit_circadian_profile([recording(spans)], shrinkage_hours=0.0)
+
+    # The interval contributes to 09, 10 and 11; with no competing labelled
+    # state each observed hour has conditional share one and therefore the same
+    # lift. Unobserved hours stay neutral.
+    assert fit.profile[S.SLEEPING][9] == pytest.approx(1.0)
+    assert fit.profile[S.SLEEPING][10] == pytest.approx(1.0)
+    assert fit.profile[S.SLEEPING][11] == pytest.approx(1.0)
+    assert fit.profile[S.SLEEPING][12] == pytest.approx(1.0)
+    assert fit.labelled_seconds == pytest.approx(7200.0)
+
+
+def test_sparse_cells_are_shrunk_toward_one() -> None:
+    no_shrink = fit_circadian_profile(
+        [recording(interval(0, 1, S.SLEEPING), interval(1, 10, S.HOME_ACTIVE))],
+        shrinkage_hours=0.0,
+        maximum_multiplier=10.0,
+    )
+    shrunk = fit_circadian_profile(
+        [recording(interval(0, 1, S.SLEEPING), interval(1, 10, S.HOME_ACTIVE))],
+        shrinkage_hours=4.0,
+        maximum_multiplier=10.0,
+    )
+
+    assert abs(shrunk.profile[S.SLEEPING][0] - 1.0) < abs(
+        no_shrink.profile[S.SLEEPING][0] - 1.0
+    )
+
+
+def test_multiplier_bounds_are_enforced() -> None:
+    fit = fit_circadian_profile(
+        [recording(interval(0, 1, S.SLEEPING), interval(1, 20, S.HOME_ACTIVE))],
+        shrinkage_hours=0.0,
+        minimum_multiplier=0.5,
+        maximum_multiplier=2.0,
+    )
+    assert min(fit.profile[S.SLEEPING]) >= 0.5
+    assert max(fit.profile[S.SLEEPING]) <= 2.0
+
+
+def test_serialisation_and_hash_are_stable() -> None:
+    recordings = [
+        recording(interval(0, 6, S.SLEEPING), interval(8, 8, S.HOME_ACTIVE))
+    ]
+    first = fit_circadian_profile(recordings)
+    second = fit_circadian_profile(recordings)
+    assert first.to_dict() == second.to_dict()
+    assert first.sha256() == second.sha256()
+    assert len(first.sha256()) == 64
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"shrinkage_hours": -1.0},
+        {"minimum_multiplier": 0.0},
+        {"minimum_multiplier": 2.0, "maximum_multiplier": 1.0},
+    ],
+)
+def test_invalid_fit_configuration_is_rejected(kwargs: dict[str, float]) -> None:
+    with pytest.raises(ValueError):
+        fit_circadian_profile([recording(interval(0, 1, S.SLEEPING))], **kwargs)


### PR DESCRIPTION
Closes the last reproducibility gap before the frozen v0.3 external-validation candidate can be instantiated.

PR #106 freezes the candidate form as v0.2 plus the circadian prior from #102. The development experiment in #102 fitted its 24-hour state profiles ad hoc and committed only the performance summary, not a reusable fitting implementation. This PR makes that fit deterministic and auditable without scoring any external-test home.

`fit_circadian_profile` estimates each state/hour stickiness multiplier as the annotated occupancy lift `P(Z=z | H=h) / P(Z=z)`, splits intervals exactly at hour boundaries, shrinks sparse cells toward one by an explicit equivalent-duration prior, and clips to positive declared bounds. States absent from development annotations remain neutral rather than receiving invented patterns.

`CircadianProfileFit` serialises the complete profile and fit settings in canonical form and exposes a SHA-256, so the final all-22-development-home profile can be committed with an exact fingerprint before any untouched-home scoring.

Tests cover state-hour direction, absent-state neutrality, hour-boundary splitting, sparse-cell shrinkage, clipping bounds, deterministic serialisation/hash, and invalid configurations.

This PR does not fit the 22-home profile, change default inference behaviour, alter the v0.3 candidate specification, or inspect any primary external-test outcome.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the last reproducibility gap before the v0.3 external-validation candidate can be instantiated by adding a deterministic circadian profile fitter. The fit derives per-state/hour stickiness multipliers from development annotations only and never inspects external-test outcomes.

**New Features**
- New `fit_circadian_profile` estimates each state/hour stickiness multiplier as the occupancy lift `P(Z=z|H=h)/P(Z=z)`, splits intervals at hour boundaries, shrinks sparse cells via an equivalent-duration prior, and clips to declared positive bounds.
- States absent from development annotations stay neutral rather than receiving invented circadian patterns.
- `CircadianProfileFit` serialises the profile and fit settings in canonical form and exposes a SHA-256 fingerprint for committing the final all-22-home profile.
- This PR does not fit the 22-home profile or alter the v0.3 candidate specification.

<sup>Written for commit f534ec10bcfe13daaec905a194928e673d53613b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

