### PR TITLE
Freeze the final v0.3 circadian profile reproducibly

### DIFF
--- a/.github/workflows/freeze-v03-circadian-profile.yml
+++ b/.github/workflows/freeze-v03-circadian-profile.yml
@@ -1,0 +1,132 @@
+name: Freeze v0.3 circadian profile
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: freeze-v03-circadian-profile
+  cancel-in-progress: false
+
+env:
+  ZENODO_RECORD: "15708568"
+  OUTPUT_DIR: v03-profile-freeze
+
+jobs:
+  fit:
+    name: fit development-only profile
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+
+    steps:
+      - name: Require manual develop dispatch
+        shell: bash
+        run: |
+          test "$GITHUB_EVENT_NAME" = "workflow_dispatch"
+          test "$GITHUB_REF" = "refs/heads/develop"
+
+      - name: Check out fitting revision
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+
+      - name: Download and verify public CASAS archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p casas-archive "$OUTPUT_DIR"
+          python - <<'PY'
+          import hashlib
+          import json
+          import urllib.request
+          from pathlib import Path
+
+          record = "15708568"
+          with urllib.request.urlopen(f"https://zenodo.org/api/records/{record}") as response:
+              meta = json.load(response)
+
+          files = meta.get("files", [])
+          candidates = [item for item in files if item.get("key") == "labeled_data.zip"]
+          if len(candidates) != 1:
+              raise SystemExit(f"expected one labeled_data.zip in Zenodo metadata, got {len(candidates)}")
+          item = candidates[0]
+          url = item["links"]["self"]
+          checksum = item.get("checksum", "")
+          target = Path("casas-archive/labeled_data.zip")
+          urllib.request.urlretrieve(url, target)
+
+          if checksum:
+              algorithm, expected = checksum.split(":", 1)
+              h = hashlib.new(algorithm)
+              with target.open("rb") as handle:
+                  for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                      h.update(chunk)
+              if h.hexdigest() != expected:
+                  raise SystemExit(
+                      f"Zenodo archive checksum mismatch: {h.hexdigest()} != {expected}"
+                  )
+
+          Path("v03-profile-freeze/source_metadata.json").write_text(
+              json.dumps(
+                  {
+                      "record": record,
+                      "file": item.get("key"),
+                      "bytes": item.get("size"),
+                      "checksum": checksum,
+                  },
+                  indent=2,
+                  sort_keys=True,
+              ) + "\n",
+              encoding="utf-8",
+          )
+          PY
+          unzip -q casas-archive/labeled_data.zip -d casas-archive/extracted
+
+      - name: Reconstruct 22-home development cohort and fit profile
+        shell: bash
+        run: |
+          python scripts/freeze_v03_circadian_profile.py \
+            casas-archive/extracted \
+            "$OUTPUT_DIR/v03_circadian_profile.json" \
+            --source-record "$ZENODO_RECORD" \
+            --fitting-revision "$GITHUB_SHA"
+
+      - name: Verify frozen output without scoring homes
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path("v03-profile-freeze/v03_circadian_profile.json").read_text())
+          assert payload["status"] == "frozen-development-fit"
+          assert payload["candidate"] == "v0.2 + circadian prior only"
+          assert payload["development_home_count"] == 22
+          assert len(payload["development_homes"]) == 22
+          assert len({row["id"] for row in payload["development_homes"]}) == 22
+          assert len({row["sha256"] for row in payload["development_homes"]}) == 22
+          assert len(payload["profile_sha256"]) == 64
+          assert payload["test_outcomes_inspected"] is False
+          assert payload["fitting_revision"] == "${{ github.sha }}"
+          PY
+
+      - name: Upload development-fit freeze artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: v03-circadian-profile-freeze
+          path: v03-profile-freeze/
+          retention-days: 90
+          if-no-files-found: error

--- a/scripts/freeze_v03_circadian_profile.py
+++ b/scripts/freeze_v03_circadian_profile.py
@@ -1,0 +1,118 @@
+"""Reconstruct the development cohort and freeze the v0.3 circadian profile.
+
+This script is intentionally outcome-blind. It uses only archive metadata and
+activity annotations from the already-declared development cohort. It never
+runs the behavioural inference model and therefore cannot inspect primary
+external-test outcomes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from sensor_modeling.datasets import fit_circadian_profile, read_casas_hh
+
+HH_NAME = re.compile(r"^hh\d+.*\.csv$", re.IGNORECASE)
+EXPECTED_DEVELOPMENT_HOMES = 22
+DECIMAL_LIMIT = 12_000_000
+BINARY_LIMIT = 12 * 1024 * 1024
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _candidates(root: Path, limit: int) -> list[Path]:
+    return sorted(
+        (
+            path
+            for path in root.rglob("*.csv")
+            if HH_NAME.match(path.name) and path.stat().st_size < limit
+        ),
+        key=lambda path: path.name.lower(),
+    )
+
+
+def _reconstruct(root: Path) -> tuple[list[Path], str, int]:
+    """Recover the documented 22-home cohort from metadata only.
+
+    Historical prose says "under 12 MB" but did not retain whether MB meant
+    decimal or MiB. We evaluate both metadata conventions and accept a unique
+    convention only when it reproduces exactly the documented 22 homes. No
+    labels, model predictions or scores participate in this choice.
+    """
+    options = [
+        ("decimal_MB", DECIMAL_LIMIT, _candidates(root, DECIMAL_LIMIT)),
+        ("binary_MiB", BINARY_LIMIT, _candidates(root, BINARY_LIMIT)),
+    ]
+    matches = [item for item in options if len(item[2]) == EXPECTED_DEVELOPMENT_HOMES]
+    if len(matches) != 1:
+        counts = {name: len(paths) for name, _, paths in options}
+        raise SystemExit(
+            "development cohort reconstruction is ambiguous; expected exactly "
+            f"one 12 MB convention to yield {EXPECTED_DEVELOPMENT_HOMES} homes, "
+            f"got {counts}"
+        )
+    name, limit, paths = matches[0]
+    return paths, name, limit
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("archive_root", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--source-record", default="15708568")
+    parser.add_argument("--fitting-revision", required=True)
+    args = parser.parse_args()
+
+    paths, convention, byte_limit = _reconstruct(args.archive_root)
+    zone = ZoneInfo("America/Los_Angeles")
+    recordings = [read_casas_hh(path, timezone=zone) for path in paths]
+    fit = fit_circadian_profile(recordings)
+
+    homes = [
+        {
+            "id": path.stem,
+            "filename": path.name,
+            "bytes": path.stat().st_size,
+            "sha256": _sha256(path),
+        }
+        for path in paths
+    ]
+    payload = {
+        "schema_version": 1,
+        "status": "frozen-development-fit",
+        "candidate": "v0.2 + circadian prior only",
+        "source": {
+            "provider": "CASAS / Zenodo",
+            "record": str(args.source_record),
+            "archive_rule": "single-resident hh CSV under documented 12 MB cutoff",
+            "size_convention": convention,
+            "byte_limit_exclusive": byte_limit,
+        },
+        "development_home_count": len(homes),
+        "development_homes": homes,
+        "fitting_revision": args.fitting_revision,
+        "fit": fit.to_dict(),
+        "profile_sha256": fit.sha256(),
+        "test_outcomes_inspected": False,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps({"homes": [row["id"] for row in homes], "profile_sha256": fit.sha256()}))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds the final pre-test infrastructure needed to instantiate the already-frozen v0.3 candidate without inspecting any untouched-home outcome.

The new one-shot workflow downloads the public CASAS `labeled_data.zip` archive from Zenodo record `15708568`, verifies the checksum declared by Zenodo metadata, and reconstructs the historical 22-home development cohort using metadata only. The repository documentation retained the rule as single-resident `hh` recordings "under 12 MB" but did not retain whether MB meant decimal or MiB; the freezer evaluates both byte conventions and proceeds only if exactly one reproduces the documented 22 homes. No labels, predictions or scores participate in that reconstruction decision.

`scripts/freeze_v03_circadian_profile.py` then parses only those 22 development recordings with the existing `read_casas_hh` adapter and fits the reproducible `fit_circadian_profile` implementation merged in #108. The output records every development-home ID, filename, byte size and raw-file SHA-256, the source Zenodo record, the fitting Git revision, the full fitted profile/settings, and the profile SHA-256.

The workflow contains no model-evaluation call and asserts `test_outcomes_inspected=false`. It uploads only the metadata/profile freeze artifact; the CASAS dataset is not redistributed.

This PR does not change the candidate model form frozen in #106, does not add smoothing/rate/dwell components, does not score any primary test home, and does not alter the simulator-confirmatory evidence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-shot workflow that downloads and verifies the public CASAS archive from Zenodo record `15708568`, reconstructs the 22-home development cohort from metadata only, and freezes the reproducible v0.3 circadian profile. The process is outcome-blind: it never runs the inference model and asserts `test_outcomes_inspected=false`.

- Evaluates both decimal MB and MiB readings of the historical "under 12 MB" rule and proceeds only if exactly one reproduces the 22 documented homes.
- Records each development-home ID, filename, byte size, SHA-256, source record, fitting revision, fitted profile, and profile SHA-256.
- Uploads only the metadata/profile freeze artifact; the CASAS dataset is not redistributed.
- Does not change the candidate model form, add smoothing/rate/dwell components, score primary test homes, or alter simulator-confirmatory evidence.

<sup>Written for commit 8416a6b7b275510ad282f2a613d20a083de0005c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

