### PR TITLE
Format the circadian fitting files

### DIFF
--- a/scripts/freeze_v03_circadian_profile.py
+++ b/scripts/freeze_v03_circadian_profile.py
@@ -111,7 +111,11 @@ def main() -> None:
         json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
         encoding="utf-8",
     )
-    print(json.dumps({"homes": [row["id"] for row in homes], "profile_sha256": fit.sha256()}))
+    print(
+        json.dumps(
+            {"homes": [row["id"] for row in homes], "profile_sha256": fit.sha256()}
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/sensor_modeling/datasets/circadian.py
+++ b/sensor_modeling/datasets/circadian.py
@@ -16,12 +16,12 @@ and therefore cannot inspect external-test outcomes.
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
-from datetime import datetime, timedelta
 import hashlib
 import json
 import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta
 
 from ..states import BehaviouralState, StateOntology
 from .casas import CasasRecording
@@ -131,9 +131,7 @@ def fit_circadian_profile(
         raise ValueError("multiplier bounds must be positive and ordered")
 
     states = ontology or StateOntology()
-    per_state_hour = {
-        state: [0.0 for _ in range(24)] for state in states.states
-    }
+    per_state_hour = {state: [0.0 for _ in range(24)] for state in states.states}
     per_hour = [0.0 for _ in range(24)]
     per_state = {state: 0.0 for state in states.states}
     labelled_total = 0.0
@@ -167,13 +165,10 @@ def fit_circadian_profile(
                 lift = 1.0
             else:
                 conditional_share = (
-                    per_state_hour[state][hour]
-                    + shrinkage_seconds * overall_share
+                    per_state_hour[state][hour] + shrinkage_seconds * overall_share
                 ) / (hour_total + shrinkage_seconds)
                 lift = conditional_share / overall_share
-            values.append(
-                min(max(float(lift), minimum_multiplier), maximum_multiplier)
-            )
+            values.append(min(max(float(lift), minimum_multiplier), maximum_multiplier))
         profile[state] = tuple(values)
 
     return CircadianProfileFit(

--- a/tests/test_circadian_fit.py
+++ b/tests/test_circadian_fit.py
@@ -56,9 +56,7 @@ def test_an_absent_state_gets_a_neutral_profile() -> None:
 
 def test_intervals_are_split_across_hour_boundaries() -> None:
     start = datetime(2024, 1, 1, 9, 30, tzinfo=UTC)
-    spans = ActivityInterval(
-        "sleep", start, start + timedelta(hours=2), S.SLEEPING
-    )
+    spans = ActivityInterval("sleep", start, start + timedelta(hours=2), S.SLEEPING)
     fit = fit_circadian_profile([recording(spans)], shrinkage_hours=0.0)
 
     # The interval contributes to 09, 10 and 11; with no competing labelled
@@ -100,9 +98,7 @@ def test_multiplier_bounds_are_enforced() -> None:
 
 
 def test_serialisation_and_hash_are_stable() -> None:
-    recordings = [
-        recording(interval(0, 6, S.SLEEPING), interval(8, 8, S.HOME_ACTIVE))
-    ]
+    recordings = [recording(interval(0, 6, S.SLEEPING), interval(8, 8, S.HOME_ACTIVE))]
     first = fit_circadian_profile(recordings)
     second = fit_circadian_profile(recordings)
     assert first.to_dict() == second.to_dict()


### PR DESCRIPTION
`develop` is failing lint. The last two runs on it both fail the same way: unsorted imports in `sensor_modeling/datasets/circadian.py` and black formatting across that file, `tests/test_circadian_fit.py` and `scripts/freeze_v03_circadian_profile.py`.

Formatting only — `git diff -w` shows the same three files and no logic change. The 19 circadian tests still pass.

Worth noting how this got in: the `all checks passed` gate did flag it, but `enforce_admins` is off on the protection rule, so an admin merge goes through regardless. That is deliberate — it keeps you able to override — but it means the gate reports rather than blocks for you specifically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Formats the circadian fitting files so `develop` stops failing lint. Diff is formatting-only — no logic change, and the 19 circadian tests pass.

<sup>Written for commit adb58f0767b834cf92c1736b93e0e506f08d69ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

