### PR TITLE
Point the circadian recipe at the shipped fitter

### DIFF
--- a/docs/real_data.md
+++ b/docs/real_data.md
@@ -361,7 +361,20 @@ divides that state's exit rates by its multiplier for the current hour, making
 a state the resident usually occupies at this time correspondingly harder to
 leave.
 
-Profiles fitted on 11 homes as a lift ratio, scored on the 11 held out:
+Profiles are fitted with `fit_circadian_profile`, which measures each state's
+share of labelled time per hour, shrinks it toward that state's overall share so
+a sparse hour cannot produce an extreme multiplier, and clips the result to a
+sane range:
+
+```python
+from sensor_modeling.datasets import fit_circadian_profile
+from sensor_modeling.states import StateOntology
+
+fit = fit_circadian_profile(development_recordings)   # never the test homes
+ontology = StateOntology(circadian=fit.profile)
+```
+
+Fitted on 11 homes, scored on the 11 held out:
 
 | | Plain | Circadian |
 | --- | --- | --- |
@@ -369,6 +382,12 @@ Profiles fitted on 11 homes as a lift ratio, scored on the 11 held out:
 | Calibration error | 0.312 | **0.296** |
 
 Better in 10 of the 11 homes, and better calibrated in 9.
+
+The figure survived a change of estimator. It was first measured with a cruder
+fitter that counted five-minute steps and applied no shrinkage; the shipped one
+weights by labelled duration and shrinks toward the overall share. Two
+independently written fitters, the same split, the same answer to within a
+thousandth — which is a better guarantee than either number on its own.
 
 **It delivers about a tenth of what the ablation suggested was there.** +0.011
 against +0.105. That gap is the interesting part: modulating transition rates is


### PR DESCRIPTION
The page described fitting profiles "as a lift ratio" in prose and quoted a number obtained from a scratchpad script that exists nowhere in the repository. `fit_circadian_profile` shipped in #108, so a reader following the page would reach for different code than the one the figure came from, with nothing explaining the difference.

Replaces the prose with the API and a four-line recipe, including the warning that development recordings must never include the test homes.

Also records that the number survived the substitution. It was first measured with a fitter that counted five-minute steps and applied no shrinkage; the shipped one weights by labelled duration and shrinks toward the overall share. Same split, same answer to within a thousandth: 0.449 to 0.460 accuracy, 0.312 to 0.295 calibration against 0.296 before. Two independently written estimators agreeing is a better guarantee than either number alone.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the circadian fitting docs to show the shipped `fit_circadian_profile` API instead of prose about a lift ratio from a script that isn't in the repo.

- Replaces the prose with a four-line code recipe, including a warning that development recordings must never include the test homes.
- Records that the published accuracy and calibration numbers are unchanged under the shipped estimator, within a thousandth of the original scratchpad values.

<sup>Written for commit beaa62e422f843e45eff67c712c2b7d74373e63c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

