### PR TITLE
Fix the v0.3 specification's references and rendering

### DIFF
--- a/docs/V03_CANDIDATE_SPECIFICATION.md
+++ b/docs/V03_CANDIDATE_SPECIFICATION.md
@@ -4,7 +4,7 @@
 
 **Prospective candidate specification — primary external test outcomes remain uninspected.**
 
-This document selects the model form that will be frozen for the one-shot external validation defined in `docs/EXTERNAL_VALIDATION_CONTRACT.md`. It uses only evidence already obtained from the 22-home CASAS `hh` development panel.
+This document selects the model form that will be frozen for the one-shot external validation defined in `papers/failure-aware-multimodal-behavioural-sensing/EXTERNAL_VALIDATION_CONTRACT.md`. It uses only evidence already obtained from the 22-home CASAS `hh` development panel.
 
 ## Candidate
 
@@ -74,11 +74,11 @@ Any subsequent modification defines a new exploratory or future model version.
 
 ## Primary estimand
 
-For eligible test home `h`,
+For eligible test home `h`, the paired difference is
 
-\[
-D_h = BA_h^{(v0.3)} - BA_h^{(v0.2)}.
-\]
+```text
+D_h = BA_h(v0.3) - BA_h(v0.2)
+```
 
 The primary summary is the mean paired household difference with the interval procedure frozen in the external-validation contract. Time points are observations, not independent replications.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
       - Uncertainty model: UNCERTAINTY_MODEL.md
       - Evaluation design: EVALUATION_DESIGN.md
       - Simulation protocols: SIMULATION_PROTOCOLS.md
+      - v0.3 candidate specification: V03_CANDIDATE_SPECIFICATION.md
       - Adversarial review: ADVERSARIAL_REVIEW.md
       - Release readiness: RELEASE_READINESS.md
   - Modelling core:


### PR DESCRIPTION
Three defects in the v0.3 candidate specification, all of which affect whether a reader can act on it.

**The contract path did not resolve.** The document twice cites `docs/EXTERNAL_VALIDATION_CONTRACT.md` as the source of the eligible cohort and the interval procedure. The file exists at `papers/failure-aware-multimodal-behavioural-sensing/EXTERNAL_VALIDATION_CONTRACT.md`. Since the two things it freezes are exactly what the spec defers to it for, a reader following the citation found nothing.

**The estimand rendered as literal backslashes.** This project configures no math extension, so `\[ D_h = BA_h^{(v0.3)} ... \]` displays as source. Rewritten in the plain-text form the other pages use.

**The page was orphaned.** It was the only file in `docs/` absent from the mkdocs nav, so it built and published but was reachable only by guessing the URL. Added under Design records beside the simulation protocols.

Content unchanged: no claim, number, decision or procedure is altered.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three defects in the v0.3 candidate specification so a reader can actually act on it: the contract citation pointed to a file that doesn't exist, the estimand rendered as literal backslashes, and the page was missing from the docs navigation. No claims, numbers, or procedures change.

- The contract path now points to `papers/failure-aware-multimodal-behavioural-sensing/EXTERNAL_VALIDATION_CONTRACT.md`.
- The estimand is rewritten in the plain-text code block style the other docs pages use.
- The page is now listed under Design records in `mkdocs.yml` beside the simulation protocols.

<sup>Written for commit d53576111689409b496bfba7263a10c7c09fead0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

