### PR TITLE
Validate the frozen v0.3 profile artifact independently

### DIFF
--- a/scripts/validate_v03_profile_freeze.py
+++ b/scripts/validate_v03_profile_freeze.py
@@ -27,7 +27,9 @@ def _canonical_fit_sha256(fit: dict[str, object]) -> str:
     return hashlib.sha256(payload).hexdigest()
 
 
-def validate(payload: dict[str, object], *, expected_revision: str | None = None) -> None:
+def validate(
+    payload: dict[str, object], *, expected_revision: str | None = None
+) -> None:
     assert payload["schema_version"] == 1
     assert payload["status"] == "frozen-development-fit"
     assert payload["candidate"] == EXPECTED_CANDIDATE

--- a/scripts/validate_v03_profile_freeze.py
+++ b/scripts/validate_v03_profile_freeze.py
@@ -1,0 +1,100 @@
+"""Validate a frozen v0.3 circadian-profile artifact without scoring homes."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+EXPECTED_CANDIDATE = "v0.2 + circadian prior only"
+EXPECTED_HOME_COUNT = 22
+EXPECTED_PROFILE_STATES = {
+    "away",
+    "bathroom_activity",
+    "bed_awake",
+    "home_active",
+    "home_inactive",
+    "kitchen_activity",
+    "sleeping",
+}
+
+
+def _canonical_fit_sha256(fit: dict[str, object]) -> str:
+    payload = json.dumps(
+        fit, sort_keys=True, separators=(",", ":"), allow_nan=False
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def validate(payload: dict[str, object], *, expected_revision: str | None = None) -> None:
+    assert payload["schema_version"] == 1
+    assert payload["status"] == "frozen-development-fit"
+    assert payload["candidate"] == EXPECTED_CANDIDATE
+    assert payload["test_outcomes_inspected"] is False
+    assert payload["development_home_count"] == EXPECTED_HOME_COUNT
+
+    homes = payload["development_homes"]
+    assert isinstance(homes, list)
+    assert len(homes) == EXPECTED_HOME_COUNT
+    ids = [row["id"] for row in homes]
+    names = [row["filename"] for row in homes]
+    digests = [row["sha256"] for row in homes]
+    assert len(set(ids)) == EXPECTED_HOME_COUNT
+    assert len(set(names)) == EXPECTED_HOME_COUNT
+    assert len(set(digests)) == EXPECTED_HOME_COUNT
+    for row in homes:
+        assert isinstance(row["bytes"], int) and row["bytes"] > 0
+        assert isinstance(row["sha256"], str) and len(row["sha256"]) == 64
+
+    source = payload["source"]
+    assert source["provider"] == "CASAS / Zenodo"
+    assert source["record"] == "15708568"
+    assert source["size_convention"] in {"decimal_MB", "binary_MiB"}
+    assert source["byte_limit_exclusive"] in {12_000_000, 12 * 1024 * 1024}
+    assert all(row["bytes"] < source["byte_limit_exclusive"] for row in homes)
+
+    fit = payload["fit"]
+    profile = fit["profile"]
+    assert set(profile) == EXPECTED_PROFILE_STATES
+    assert fit["recordings"] == EXPECTED_HOME_COUNT
+    assert fit["labelled_seconds"] > 0
+    minimum = float(fit["minimum_multiplier"])
+    maximum = float(fit["maximum_multiplier"])
+    assert minimum > 0
+    assert maximum >= minimum
+    for values in profile.values():
+        assert len(values) == 24
+        assert all(minimum <= float(value) <= maximum for value in values)
+
+    expected_hash = _canonical_fit_sha256(fit)
+    assert payload["profile_sha256"] == expected_hash
+    assert len(expected_hash) == 64
+
+    if expected_revision is not None:
+        assert payload["fitting_revision"] == expected_revision
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("artifact", type=Path)
+    parser.add_argument("--expected-revision")
+    args = parser.parse_args()
+
+    payload = json.loads(args.artifact.read_text(encoding="utf-8"))
+    validate(payload, expected_revision=args.expected_revision)
+    print(
+        json.dumps(
+            {
+                "valid_v03_profile_freeze": True,
+                "profile_sha256": payload["profile_sha256"],
+                "fitting_revision": payload["fitting_revision"],
+                "development_home_count": payload["development_home_count"],
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds an independent validator for the development-only v0.3 circadian-profile freeze artifact before that artifact can be accepted into the repository.

The validator checks the frozen schema/status/candidate, exactly 22 unique development homes, positive file sizes and SHA-256s, Zenodo record and size-rule consistency, the seven-state × 24-hour profile shape, multiplier bounds, fit recording count and labelled duration, and independently recomputes the canonical profile SHA-256 from the embedded fit object. It can also require the exact fitting Git revision.

It explicitly requires `test_outcomes_inspected=false` and contains no inference or evaluation call. This PR does not score any external home, change the v0.3 candidate, or inspect an external-test outcome.

The manual `Freeze v0.3 circadian profile` workflow still has not been dispatched; this PR prepares the acceptance gate for its first artifact.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an independent validator for the frozen v0.3 circadian-profile artifact so the repository's acceptance gate can run before the artifact is merged.

- Checks schema, status, candidate, 22 unique development homes, positive file sizes and SHA-256s, Zenodo record and size-rule consistency, and the seven-state × 24-hour profile shape and multiplier bounds.
- Recomputes the canonical profile SHA-256 from the embedded fit object and can require the exact fitting Git revision.
- Requires `test_outcomes_inspected=false` and performs no inference or evaluation, so it never scores a home or inspects a test outcome.

<sup>Written for commit 185ab937c0579717076ada7fe3217551e924bd12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

