### PR TITLE
Accept a cohort both size conventions agree on

### DIFF
--- a/scripts/freeze_v03_circadian_profile.py
+++ b/scripts/freeze_v03_circadian_profile.py
@@ -42,27 +42,60 @@ def _candidates(root: Path, limit: int) -> list[Path]:
     )
 
 
+def _agreeing_conventions(root: Path) -> list[str]:
+    """Return every 12 MB convention that selects the documented cohort.
+
+    More than one means the prose's decimal/binary ambiguity never mattered:
+    they pick the same files, so the cohort is determined by the archive.
+    """
+    return [
+        name
+        for name, limit in (("decimal_MB", DECIMAL_LIMIT), ("binary_MiB", BINARY_LIMIT))
+        if len(_candidates(root, limit)) == EXPECTED_DEVELOPMENT_HOMES
+    ]
+
+
 def _reconstruct(root: Path) -> tuple[list[Path], str, int]:
     """Recover the documented 22-home cohort from metadata only.
 
     Historical prose says "under 12 MB" but did not retain whether MB meant
-    decimal or MiB. We evaluate both metadata conventions and accept a unique
-    convention only when it reproduces exactly the documented 22 homes. No
-    labels, model predictions or scores participate in this choice.
+    decimal or MiB. Both metadata conventions are evaluated. What matters is
+    whether they disagree about *which* homes are selected, not how many
+    conventions happen to yield the documented count: if every convention
+    reaching 22 homes selects the same 22, the cohort is determined and the
+    prose's ambiguity never mattered. Only a disagreement about membership is
+    genuinely unresolvable from metadata.
+
+    No labels, model predictions or scores participate in this choice.
     """
     options = [
         ("decimal_MB", DECIMAL_LIMIT, _candidates(root, DECIMAL_LIMIT)),
         ("binary_MiB", BINARY_LIMIT, _candidates(root, BINARY_LIMIT)),
     ]
     matches = [item for item in options if len(item[2]) == EXPECTED_DEVELOPMENT_HOMES]
-    if len(matches) != 1:
+    if not matches:
         counts = {name: len(paths) for name, _, paths in options}
         raise SystemExit(
-            "development cohort reconstruction is ambiguous; expected exactly "
-            f"one 12 MB convention to yield {EXPECTED_DEVELOPMENT_HOMES} homes, "
-            f"got {counts}"
+            "development cohort reconstruction failed; no 12 MB convention "
+            f"yields {EXPECTED_DEVELOPMENT_HOMES} homes, got {counts}"
         )
-    name, limit, paths = matches[0]
+
+    selections = {tuple(path.name for path in paths) for _, _, paths in matches}
+    if len(selections) != 1:
+        raise SystemExit(
+            "development cohort reconstruction is ambiguous; the 12 MB "
+            "conventions each yield "
+            f"{EXPECTED_DEVELOPMENT_HOMES} homes but disagree on which: "
+            + "; ".join(
+                f"{name}={[path.name for path in paths]}" for name, _, paths in matches
+            )
+        )
+
+    # Record a single convention so the artefact stays within the validator's
+    # vocabulary, and the strictest limit, since every matching convention
+    # selected the same files anyway. The agreement itself is recorded
+    # alongside it.
+    name, limit, paths = min(matches, key=lambda item: item[1])
     return paths, name, limit
 
 
@@ -97,6 +130,7 @@ def main() -> None:
             "record": str(args.source_record),
             "archive_rule": "single-resident hh CSV under documented 12 MB cutoff",
             "size_convention": convention,
+            "equivalent_size_conventions": _agreeing_conventions(args.archive_root),
             "byte_limit_exclusive": byte_limit,
         },
         "development_home_count": len(homes),

--- a/scripts/validate_v03_profile_freeze.py
+++ b/scripts/validate_v03_profile_freeze.py
@@ -54,6 +54,22 @@ def validate(
     assert source["record"] == "15708568"
     assert source["size_convention"] in {"decimal_MB", "binary_MiB"}
     assert source["byte_limit_exclusive"] in {12_000_000, 12 * 1024 * 1024}
+    # Where more than one 12 MB convention selects the documented cohort, the
+    # recorded one must be among them: the prose ambiguity is then resolved by
+    # the archive itself rather than by a choice made during fitting.
+    equivalent = source.get("equivalent_size_conventions")
+    if equivalent is not None:
+        assert isinstance(equivalent, list) and equivalent
+        assert set(equivalent) <= {"decimal_MB", "binary_MiB"}
+        assert source["size_convention"] in equivalent
+    # Where more than one 12 MB convention selects the documented cohort, the
+    # recorded one must be among them: the prose ambiguity is then resolved by
+    # the files themselves rather than by a choice made here.
+    equivalent = source.get("equivalent_size_conventions")
+    if equivalent is not None:
+        assert isinstance(equivalent, list) and equivalent
+        assert set(equivalent) <= {"decimal_MB", "binary_MiB"}
+        assert source["size_convention"] in equivalent
     assert all(row["bytes"] < source["byte_limit_exclusive"] for row in homes)
 
     fit = payload["fit"]


### PR DESCRIPTION
The v0.3 profile freeze workflow fails:

```
development cohort reconstruction is ambiguous; expected exactly one 12 MB
convention to yield 22 homes, got {'decimal_MB': 22, 'binary_MiB': 22}
```

The guard is right to worry — the prose said "under 12 MB" without recording whether MB meant decimal or MiB — but it tests the wrong thing. It refuses when both conventions yield 22 homes, when the question is whether they select the **same** 22.

They do. The largest included file is `hh108` at 11,901,894 bytes and the smallest excluded is `hh104` at 13,977,124, so the cohort sits in a 2.1 MB gap and is identical under either convention. The ambiguity in the prose never reached the data.

The guard now refuses only on disagreement about membership, and reports which homes each convention chose when it does.

Two things kept deliberate. The artefact records a single `size_convention` from the validator's existing vocabulary rather than a combined string — my first attempt emitted `decimal_MB+binary_MiB`, which the merged validator rejects on `size_convention in {decimal_MB, binary_MiB}`. The agreement is recorded separately as `equivalent_size_conventions`, and the validator now checks that the recorded convention is among them, so the artefact carries the evidence that the choice did not matter.

Verified end to end against the real Zenodo archive: the freezer produces a profile over the 22 homes and the independent validator accepts it, with `profile_sha256` identical across runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the v0.3 profile freeze workflow so a development cohort selected identically by both 12 MB size conventions is accepted instead of rejected as ambiguous.

- The guard now fails only when the decimal and binary conventions disagree about which homes belong to the cohort.
- The freezer records every agreeing convention as `equivalent_size_conventions` next to the single `size_convention`.
- The validator now requires the recorded `size_convention` to be present in `equivalent_size_conventions`.
- Verified against the real Zenodo archive; `profile_sha256` is identical across runs.

<sup>Written for commit ed4b40699db4e5f6ff081ca5023c2460cc741011. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

