### PR TITLE
Accept invariant 12 MB development cohort

### DIFF
--- a/scripts/freeze_v03_circadian_profile.py
+++ b/scripts/freeze_v03_circadian_profile.py
@@ -21,6 +21,10 @@ HH_NAME = re.compile(r"^hh\d+.*\.csv$", re.IGNORECASE)
 EXPECTED_DEVELOPMENT_HOMES = 22
 DECIMAL_LIMIT = 12_000_000
 BINARY_LIMIT = 12 * 1024 * 1024
+SIZE_RULES = (
+    ("decimal_MB", DECIMAL_LIMIT),
+    ("binary_MiB", BINARY_LIMIT),
+)
 
 
 def _sha256(path: Path) -> str:
@@ -38,32 +42,63 @@ def _candidates(root: Path, limit: int) -> list[Path]:
             for path in root.rglob("*.csv")
             if HH_NAME.match(path.name) and path.stat().st_size < limit
         ),
-        key=lambda path: path.name.lower(),
+        key=lambda path: path.relative_to(root).as_posix().lower(),
     )
 
 
-def _reconstruct(root: Path) -> tuple[list[Path], str, int]:
+def _cohort_key(root: Path, paths: list[Path]) -> tuple[str, ...]:
+    return tuple(path.relative_to(root).as_posix() for path in paths)
+
+
+def _reconstruct(
+    root: Path,
+) -> tuple[list[Path], str, int, dict[str, dict[str, int]], bool]:
     """Recover the documented 22-home cohort from metadata only.
 
     Historical prose says "under 12 MB" but did not retain whether MB meant
-    decimal or MiB. We evaluate both metadata conventions and accept a unique
-    convention only when it reproduces exactly the documented 22 homes. No
-    labels, model predictions or scores participate in this choice.
+    decimal or MiB. Both conventions are evaluated using file metadata only.
+
+    If exactly one convention yields 22 homes, that convention is recorded. If
+    several conventions yield 22 homes and select the identical files, the
+    cohort is invariant to the ambiguity and the stricter byte limit is used as
+    the effective bound while every equivalent convention is recorded. The
+    function refuses to proceed only when no convention reproduces 22 homes or
+    when equally-sized candidate cohorts genuinely differ.
     """
     options = [
-        ("decimal_MB", DECIMAL_LIMIT, _candidates(root, DECIMAL_LIMIT)),
-        ("binary_MiB", BINARY_LIMIT, _candidates(root, BINARY_LIMIT)),
+        (name, limit, _candidates(root, limit)) for name, limit in SIZE_RULES
     ]
+    evaluation = {
+        name: {
+            "byte_limit_exclusive": limit,
+            "development_home_count": len(paths),
+        }
+        for name, limit, paths in options
+    }
     matches = [item for item in options if len(item[2]) == EXPECTED_DEVELOPMENT_HOMES]
-    if len(matches) != 1:
+    if not matches:
         counts = {name: len(paths) for name, _, paths in options}
         raise SystemExit(
-            "development cohort reconstruction is ambiguous; expected exactly "
-            f"one 12 MB convention to yield {EXPECTED_DEVELOPMENT_HOMES} homes, "
+            "development cohort reconstruction failed; expected at least one "
+            f"12 MB convention to yield {EXPECTED_DEVELOPMENT_HOMES} homes, "
             f"got {counts}"
         )
-    name, limit, paths = matches[0]
-    return paths, name, limit
+
+    if len(matches) == 1:
+        name, limit, paths = matches[0]
+        return paths, name, limit, evaluation, False
+
+    reference_key = _cohort_key(root, matches[0][2])
+    if any(_cohort_key(root, paths) != reference_key for _, _, paths in matches[1:]):
+        raise SystemExit(
+            "development cohort reconstruction is genuinely ambiguous: multiple "
+            "12 MB conventions yield 22 homes but select different files"
+        )
+
+    names = [name for name, _, _ in matches]
+    effective_limit = min(limit for _, limit, _ in matches)
+    convention = "equivalent_" + "_and_".join(names)
+    return matches[0][2], convention, effective_limit, evaluation, True
 
 
 def main() -> None:
@@ -74,7 +109,9 @@ def main() -> None:
     parser.add_argument("--fitting-revision", required=True)
     args = parser.parse_args()
 
-    paths, convention, byte_limit = _reconstruct(args.archive_root)
+    paths, convention, byte_limit, rule_evaluation, invariant = _reconstruct(
+        args.archive_root
+    )
     zone = ZoneInfo("America/Los_Angeles")
     recordings = [read_casas_hh(path, timezone=zone) for path in paths]
     fit = fit_circadian_profile(recordings)
@@ -98,6 +135,8 @@ def main() -> None:
             "archive_rule": "single-resident hh CSV under documented 12 MB cutoff",
             "size_convention": convention,
             "byte_limit_exclusive": byte_limit,
+            "size_rule_evaluation": rule_evaluation,
+            "cohort_invariant_across_size_conventions": invariant,
         },
         "development_home_count": len(homes),
         "development_homes": homes,

--- a/scripts/validate_v03_profile_freeze.py
+++ b/scripts/validate_v03_profile_freeze.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 EXPECTED_CANDIDATE = "v0.2 + circadian prior only"
 EXPECTED_HOME_COUNT = 22
+DECIMAL_LIMIT = 12_000_000
+BINARY_LIMIT = 12 * 1024 * 1024
 EXPECTED_PROFILE_STATES = {
     "away",
     "bathroom_activity",
@@ -25,6 +27,36 @@ def _canonical_fit_sha256(fit: dict[str, object]) -> str:
         fit, sort_keys=True, separators=(",", ":"), allow_nan=False
     ).encode("utf-8")
     return hashlib.sha256(payload).hexdigest()
+
+
+def _validate_size_rule(source: dict[str, object], homes: list[dict[str, object]]) -> None:
+    convention = source["size_convention"]
+    limit = source["byte_limit_exclusive"]
+    evaluation = source.get("size_rule_evaluation")
+    invariant = source.get("cohort_invariant_across_size_conventions", False)
+
+    if convention in {"decimal_MB", "binary_MiB"}:
+        expected_limit = DECIMAL_LIMIT if convention == "decimal_MB" else BINARY_LIMIT
+        assert limit == expected_limit
+        assert invariant is False
+    else:
+        assert convention == "equivalent_decimal_MB_and_binary_MiB"
+        assert limit == DECIMAL_LIMIT
+        assert invariant is True
+        assert isinstance(evaluation, dict)
+        assert evaluation == {
+            "decimal_MB": {
+                "byte_limit_exclusive": DECIMAL_LIMIT,
+                "development_home_count": EXPECTED_HOME_COUNT,
+            },
+            "binary_MiB": {
+                "byte_limit_exclusive": BINARY_LIMIT,
+                "development_home_count": EXPECTED_HOME_COUNT,
+            },
+        }
+
+    assert isinstance(limit, int)
+    assert all(int(row["bytes"]) < limit for row in homes)
 
 
 def validate(
@@ -50,14 +82,15 @@ def validate(
         assert isinstance(row["sha256"], str) and len(row["sha256"]) == 64
 
     source = payload["source"]
+    assert isinstance(source, dict)
     assert source["provider"] == "CASAS / Zenodo"
     assert source["record"] == "15708568"
-    assert source["size_convention"] in {"decimal_MB", "binary_MiB"}
-    assert source["byte_limit_exclusive"] in {12_000_000, 12 * 1024 * 1024}
-    assert all(row["bytes"] < source["byte_limit_exclusive"] for row in homes)
+    _validate_size_rule(source, homes)
 
     fit = payload["fit"]
+    assert isinstance(fit, dict)
     profile = fit["profile"]
+    assert isinstance(profile, dict)
     assert set(profile) == EXPECTED_PROFILE_STATES
     assert fit["recordings"] == EXPECTED_HOME_COUNT
     assert fit["labelled_seconds"] > 0


### PR DESCRIPTION
Fixes the pre-fit guard exposed by the first one-shot v0.3 profile-freeze run.

The failed run showed `decimal_MB: 22` and `binary_MiB: 22`. Because the decimal threshold is strictly smaller than the MiB threshold, the decimal candidate set is a subset of the MiB set; equal cardinalities therefore imply the exact same 22 files. The previous guard incorrectly treated this as ambiguity and stopped before reading annotations or fitting any profile.

The freezer now handles three cases explicitly: one size convention uniquely yields 22 homes; both conventions yield the identical 22-home cohort, in which case the artifact records the cohort as invariant across conventions and uses the stricter decimal byte bound; or the conventions genuinely differ, which still fails hard.

The independent validator is updated to require the dual-rule evaluation and invariance record for the equivalent-convention case.

No model evaluation, external-test scoring, candidate-form change, or scientific result is introduced by this PR. The first failed run did not reach annotation parsing or profile fitting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the pre-fit guard so `scripts/freeze_v03_circadian_profile.py` no longer aborts when both 12 MB size conventions select the identical 22-home cohort. The previous guard treated any multi-convention match as ambiguity and stopped before reading annotations; now equivalent conventions are recorded as invariant and the stricter decimal byte bound is used, while genuinely divergent cohorts still fail hard.

`scripts/validate_v03_profile_freeze.py` now requires the size-rule evaluation and invariance flag when the equivalent-convention case is recorded. No model evaluation, external-test scoring, candidate-form change, or scientific result is introduced.

<sup>Written for commit 5e68b2000cbd85ed795755b51706339791a6fd75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

