### PR TITLE
Format the v0.3 size-rule fix

### DIFF
--- a/scripts/freeze_v03_circadian_profile.py
+++ b/scripts/freeze_v03_circadian_profile.py
@@ -65,9 +65,7 @@ def _reconstruct(
     function refuses to proceed only when no convention reproduces 22 homes or
     when equally-sized candidate cohorts genuinely differ.
     """
-    options = [
-        (name, limit, _candidates(root, limit)) for name, limit in SIZE_RULES
-    ]
+    options = [(name, limit, _candidates(root, limit)) for name, limit in SIZE_RULES]
     evaluation = {
         name: {
             "byte_limit_exclusive": limit,
@@ -75,7 +73,9 @@ def _reconstruct(
         }
         for name, limit, paths in options
     }
-    matches = [item for item in options if len(item[2]) == EXPECTED_DEVELOPMENT_HOMES]
+    matches = [
+        item for item in options if len(item[2]) == EXPECTED_DEVELOPMENT_HOMES
+    ]
     if not matches:
         counts = {name: len(paths) for name, _, paths in options}
         raise SystemExit(
@@ -89,7 +89,9 @@ def _reconstruct(
         return paths, name, limit, evaluation, False
 
     reference_key = _cohort_key(root, matches[0][2])
-    if any(_cohort_key(root, paths) != reference_key for _, _, paths in matches[1:]):
+    if any(
+        _cohort_key(root, paths) != reference_key for _, _, paths in matches[1:]
+    ):
         raise SystemExit(
             "development cohort reconstruction is genuinely ambiguous: multiple "
             "12 MB conventions yield 22 homes but select different files"

--- a/scripts/validate_v03_profile_freeze.py
+++ b/scripts/validate_v03_profile_freeze.py
@@ -29,7 +29,9 @@ def _canonical_fit_sha256(fit: dict[str, object]) -> str:
     return hashlib.sha256(payload).hexdigest()
 
 
-def _validate_size_rule(source: dict[str, object], homes: list[dict[str, object]]) -> None:
+def _validate_size_rule(
+    source: dict[str, object], homes: list[dict[str, object]]
+) -> None:
     convention = source["size_convention"]
     limit = source["byte_limit_exclusive"]
     evaluation = source.get("size_rule_evaluation")


### PR DESCRIPTION
Formatter-only follow-up to #117. Black reformatted only `scripts/freeze_v03_circadian_profile.py` and `scripts/validate_v03_profile_freeze.py`; no logic changes are introduced. All Python test jobs, docs, and package checks on #117 already passed, so this PR exists solely to restore the required lint gate before using the merged revision for the one-shot development-only profile fit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies Black formatting to the v0.3 profile freeze and validation scripts so the lint gate passes on the merged #117 revision; no logic changes are introduced.

<sup>Written for commit 5554075ef6f81ee9e330a2f13fa6c485809ee867. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

