### PR TITLE
Match the pinned Black version for the v0.3 freezer

### DIFF
--- a/scripts/freeze_v03_circadian_profile.py
+++ b/scripts/freeze_v03_circadian_profile.py
@@ -73,9 +73,7 @@ def _reconstruct(
         }
         for name, limit, paths in options
     }
-    matches = [
-        item for item in options if len(item[2]) == EXPECTED_DEVELOPMENT_HOMES
-    ]
+    matches = [item for item in options if len(item[2]) == EXPECTED_DEVELOPMENT_HOMES]
     if not matches:
         counts = {name: len(paths) for name, _, paths in options}
         raise SystemExit(
@@ -89,9 +87,7 @@ def _reconstruct(
         return paths, name, limit, evaluation, False
 
     reference_key = _cohort_key(root, matches[0][2])
-    if any(
-        _cohort_key(root, paths) != reference_key for _, _, paths in matches[1:]
-    ):
+    if any(_cohort_key(root, paths) != reference_key for _, _, paths in matches[1:]):
         raise SystemExit(
             "development cohort reconstruction is genuinely ambiguous: multiple "
             "12 MB conventions yield 22 homes but select different files"


### PR DESCRIPTION
Formatter-only follow-up to #118. The repository pins Black 23.9.1, whose 88-character formatting collapses two expressions that newer Black versions wrap differently. This PR applies exactly that pinned-version formatting to `scripts/freeze_v03_circadian_profile.py`; no logic, cohort rule, model, fitting estimator, or validation behaviour changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies the repository's pinned Black 23.9.1 formatting to `scripts/freeze_v03_circadian_profile.py`, collapsing two expressions that newer Black versions wrap differently. No logic, cohort rule, model, fitting estimator, or validation behavior changes.

<sup>Written for commit 640d564245a2725421407d0e5368620fe40c0e36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

