### PR TITLE
Correct the final v0.3 fit to single-resident development homes

### DIFF
--- a/.github/workflows/freeze-v03-circadian-profile.yml
+++ b/.github/workflows/freeze-v03-circadian-profile.yml
@@ -95,7 +95,7 @@ jobs:
           PY
           unzip -q casas-archive/labeled_data.zip -d casas-archive/extracted
 
-      - name: Reconstruct 22-home development cohort and fit profile
+      - name: Reconstruct 22-recording panel and fit 20 single-resident homes
         shell: bash
         run: |
           python scripts/freeze_v03_circadian_profile.py \
@@ -104,24 +104,12 @@ jobs:
             --source-record "$ZENODO_RECORD" \
             --fitting-revision "$GITHUB_SHA"
 
-      - name: Verify frozen output without scoring homes
+      - name: Validate frozen output independently
         shell: bash
         run: |
-          python - <<'PY'
-          import json
-          from pathlib import Path
-
-          payload = json.loads(Path("v03-profile-freeze/v03_circadian_profile.json").read_text())
-          assert payload["status"] == "frozen-development-fit"
-          assert payload["candidate"] == "v0.2 + circadian prior only"
-          assert payload["development_home_count"] == 22
-          assert len(payload["development_homes"]) == 22
-          assert len({row["id"] for row in payload["development_homes"]}) == 22
-          assert len({row["sha256"] for row in payload["development_homes"]}) == 22
-          assert len(payload["profile_sha256"]) == 64
-          assert payload["test_outcomes_inspected"] is False
-          assert payload["fitting_revision"] == "${{ github.sha }}"
-          PY
+          python scripts/validate_v03_profile_freeze.py \
+            "$OUTPUT_DIR/v03_circadian_profile.json" \
+            --expected-revision "$GITHUB_SHA"
 
       - name: Upload development-fit freeze artifact
         uses: actions/upload-artifact@v4

--- a/docs/V03_CANDIDATE_SPECIFICATION.md
+++ b/docs/V03_CANDIDATE_SPECIFICATION.md
@@ -50,7 +50,11 @@ Only the circadian profile differs.
 
 ## Development fitting of the final profile
 
-Before any primary test home is scored, one final circadian profile may be estimated using **all 22 development-only `hh` homes**. This is model fitting, not external evaluation.
+The previously analysed development panel contains 22 `hh` recordings. CASAS metadata identify `hh107` and `hh121` as two-resident homes. They remain permanently development-only because their outcomes were already inspected, but they are not eligible to estimate the final single-resident circadian profile.
+
+Before any primary test home is scored, one final circadian profile may therefore be estimated using the **20 single-resident homes inside the already-inspected 22-home development panel**. No untouched home may be added merely to keep the fitting count at 22.
+
+This correction is based on resident-count metadata, not model performance. The earlier all-22 development fit is retained only as a reproducibility diagnostic and is not the immutable candidate profile.
 
 The fitting procedure must be the same family used for the development experiment documented in PR #102: a per-state, per-local-hour profile derived from labelled occupancy frequencies/lift and converted to strictly positive stickiness multipliers accepted by `StateOntology`.
 
@@ -58,11 +62,12 @@ The fitting step may not inspect any primary test-home labels, sensor outcomes, 
 
 The fitted profile must be committed in a machine-readable file before scoring, together with:
 
-1. the exact 22 development-home identifiers;
-2. the fitting code revision;
-3. the profile SHA-256;
-4. a declaration that no primary test-home outcome was inspected;
-5. the exact v0.3 candidate Git revision that will be scored.
+1. the exact 22 development-panel identifiers;
+2. the exact 20 single-resident identifiers used for parameter fitting and the two metadata-based exclusions;
+3. the fitting code revision;
+4. the profile SHA-256;
+5. a declaration that no primary test-home outcome was inspected;
+6. the exact v0.3 candidate Git revision that will be scored.
 
 After that commit, the profile is immutable for the primary external test.
 
@@ -80,7 +85,7 @@ For eligible test home `h`, the paired difference is
 D_h = BA_h(v0.3) - BA_h(v0.2)
 ```
 
-The primary summary is the mean paired household difference with the interval procedure frozen in the external-validation contract. Time points are observations, not independent replications.
+The primary summary is the **median** paired household difference with the interval procedure frozen in the external-validation contract. Time points are observations, not independent replications.
 
 Secondary outcomes remain calibration error, log loss, Brier score, abstention rate, labelled/scored coverage, and state-specific recall. They do not replace the primary balanced-accuracy estimand.
 

--- a/docs/V03_PROFILE_FREEZE_VERIFICATION.md
+++ b/docs/V03_PROFILE_FREEZE_VERIFICATION.md
@@ -1,83 +1,75 @@
 # v0.3 profile freeze: verification record
 
-This records what was checked about the development-fit circadian profile
-produced by the `Freeze v0.3 circadian profile` workflow, and what was
-deliberately **not** done.
+This page records the pre-freeze circadian-profile checks and, importantly, why
+the first reproducible profile is **not** the immutable v0.3 candidate profile.
+No primary external-test outcome has been inspected.
 
-It is not the freeze commit. Committing the profile as the immutable artefact,
-with the provenance items required by
-[the candidate specification](V03_CANDIDATE_SPECIFICATION.md), is a separate
-deliberate act.
+## First reproducible run: retained as a diagnostic, not accepted
 
-## What was produced
+The `Freeze v0.3 circadian profile` workflow succeeded on revision `6684135`
+and produced:
 
 | | |
 | --- | --- |
 | Profile SHA-256 | `e5288794d591c138d29fa6a9543840122a2ea8ca23a01f068fa1b310f0206eeb` |
-| Development homes | 22, each with an individual file SHA-256 |
+| Historical development panel | 22 recordings, each with an individual file SHA-256 |
 | Size convention | `equivalent_decimal_MB_and_binary_MiB` |
-| Fitting revision | `6684135` |
 | `test_outcomes_inspected` | `false` |
 | Source | CASAS / Zenodo record 15708568, `labeled_data.zip`, checksum verified on download |
 
-## Reproducibility
+The hash was reproduced independently and the 12 MB reconstruction itself is
+stable. Both decimal MB and binary MiB select the same 22-recording historical
+panel.
 
-The same profile hash was produced three times, by two independently written
-implementations of the cohort reconstruction and on two different machines:
+However, resident-count metadata identify `hh107` and `hh121` as two-resident
+homes. The first profile fitted all 22 recordings, so it is **rejected as the
+immutable single-resident external-validation candidate profile**. Its hash is
+kept here as provenance for a reproducible development diagnostic, not as the
+profile to be scored externally.
 
-1. a local run of the guard implemented in the closed PR #116;
-2. a local run of the merged guard from PR #117;
-3. the workflow on a clean `ubuntu-24.04` runner, downloading the archive from
-   Zenodo and verifying its checksum.
+This rejection is metadata-based, not performance-based. It occurred before any
+primary external-test home was read or scored.
 
-Byte-identical output across all three. For an artefact that becomes immutable
-once committed, agreement between independent implementations is a stronger
-check than any single run.
+## Corrected final fitting set
+
+All 22 previously analysed recordings remain development-only. Prior outcome
+inspection is sufficient to exclude a recording from the primary test cohort,
+so `hh107` and `hh121` do not return to the test pool.
+
+The final circadian parameter fit is instead restricted to the 20
+single-resident members of the same already-inspected panel:
+
+`hh101`, `hh102`, `hh103`, `hh105`, `hh106`, `hh108`, `hh110`, `hh111`,
+`hh114`, `hh118`, `hh119`, `hh120`, `hh122`, `hh123`, `hh124`, `hh125`,
+`hh126`, `hh127`, `hh129`, `hh130`.
+
+No untouched home is added merely to preserve a fitting count of 22.
+
+The freezer and independent validator use schema version 2 to distinguish the
+22-recording development panel from the 20-home parameter-fitting subset and to
+record the two metadata-based exclusions explicitly. An old all-22 artifact
+cannot satisfy the new acceptance contract.
 
 ## Cohort determinacy
 
 The historical prose said "under 12 MB" without recording whether MB meant
-decimal or binary. Both conventions select the **same** 22 homes: the largest
-included file is `hh108` at 11,901,894 bytes and the smallest excluded is
-`hh104` at 13,977,124, so the cohort sits in a 2.1 MB gap and the ambiguity
-never reached the data. The artefact records that equivalence rather than
-silently picking a convention.
+decimal or binary. Both conventions select the same 22-recording panel: the
+largest included file is `hh108` at 11,901,894 bytes and the smallest excluded
+is `hh104` at 13,977,124 bytes. The ambiguity therefore does not affect panel
+membership.
 
-## Face validity
+## What remains to be done
 
-Each state's peak stickiness hour, from the fitted profile:
+- Run the corrected development-only workflow after the design correction is
+  merged and CI passes.
+- Independently validate the schema-v2 artifact: 22 quarantined panel records,
+  exactly 20 fitting homes, exclusions exactly `hh107` and `hh121`, and the
+  canonical profile SHA-256.
+- Commit that corrected profile as the immutable candidate artifact together
+  with the exact candidate revision and remaining provenance requirements.
+- Freeze the untouched single-resident primary-test cohort manifest before any
+  scoring.
 
-| State | Peak hour | Range |
-| --- | --- | --- |
-| sleeping | 04:00 | 0.25 – 2.54 |
-| bed_awake | 22:00 | 0.25 – 4.00 |
-| bathroom_activity | 07:00 | 0.31 – 2.45 |
-| away | 11:00 | 0.39 – 1.69 |
-| home_active | 12:00 | 0.25 – 1.89 |
-| kitchen_activity | 18:00 | 0.25 – 2.96 |
-| home_inactive | 21:00 | 0.25 – 2.48 |
-
-Every peak falls where ordinary daily rhythm would put it. That is a weak check
-in the sense that it could not have detected a subtly wrong profile, but it
-would have caught a badly broken one, and it did not.
-
-## Usability
-
-The profile loads into `StateOntology`, passes its construction validation, and
-drives the pipeline to completion on development recordings, moving balanced
-accuracy in the expected direction.
-
-**Those runs are in-sample.** The profile was fitted on all 22 development
-homes, so scoring any of them measures fit rather than transfer. The figures are
-not reported here as a performance estimate, and the development estimate that
-justified the candidate remains the held-out 0.449 to 0.460 from the 11/11
-split documented in [Real-data validation](real_data.md).
-
-## What was not done
-
-- The profile has **not** been committed as the immutable frozen artefact.
-- No primary test home has been read, scored, or inspected in any way.
-- The fifth provenance item required by the specification, the exact v0.3
-  candidate revision that will be scored, has not been declared.
-
-The one-shot external scoring remains unrun and unrepeatable by design.
+The one-shot external scoring remains unrun. A positive, null, or negative
+primary result will be accepted without retuning the candidate on the test
+cohort.

--- a/papers/failure-aware-multimodal-behavioural-sensing/EXTERNAL_VALIDATION_CONTRACT.md
+++ b/papers/failure-aware-multimodal-behavioural-sensing/EXTERNAL_VALIDATION_CONTRACT.md
@@ -6,13 +6,15 @@ This contract governs the real-home external validation of the paper **Failure-A
 
 ## 1. Development data are not confirmatory external test data
 
-The 22 single-resident CASAS `hh` homes already analysed in `docs/real_data.md` are designated **development-only**. Their aggregate performance, per-state recall, emission-rate fitting, supervised recoverability ceiling, and feature-ablation results have already been inspected and used to motivate model-development hypotheses. They must not be reused as the primary external-validation test set.
+The 22 CASAS `hh` recordings already analysed in `docs/real_data.md` are designated **development-only**. Resident-count metadata identify 20 of these recordings as single-resident and `hh107` and `hh121` as two-resident. All 22 remain development-only because their aggregate performance, per-state recall, emission-rate fitting, supervised recoverability ceiling, and feature-ablation results have already been inspected and used to motivate model-development hypotheses. None may be reused as the primary external-validation test set.
+
+The resident-count correction is metadata-based and was made before any primary external-test outcome was inspected. It does not release `hh107` or `hh121` back into the test pool; prior outcome inspection is sufficient to make a recording development data.
 
 Any home, recording, split, or label whose outcome was inspected before this freeze is development data, even if it was called "held out" relative to a narrower fitting step.
 
 ## 2. Primary test cohort
 
-The primary external-validation cohort consists of eligible **single-resident labelled CASAS homes outside the previously analysed `hh` development panel**.
+The primary external-validation cohort consists of eligible **single-resident labelled CASAS homes outside the entire previously analysed 22-recording `hh` development panel**.
 
 Eligibility is determined before scoring and without reference to model performance:
 
@@ -29,7 +31,7 @@ The exact eligible test-home identifiers and raw-file checksums must be frozen i
 
 ## 3. Development / test firewall
 
-The previously examined 22-home `hh` panel may be used to develop the v0.3 candidate, including:
+The previously examined 22-recording `hh` panel may be used to develop the v0.3 candidate, including:
 
 - fitting trainable emission parameters;
 - choosing a circadian parameterisation;
@@ -37,6 +39,8 @@ The previously examined 22-home `hh` panel may be used to develop the v0.3 candi
 - fixing numerical stabilisation and implementation details;
 - debugging dataset adapters;
 - establishing deterministic activity/state mappings where the dataset vocabulary requires them.
+
+For the final circadian parameter fit used by the single-resident external-validation candidate, only the 20 single-resident members of that already-inspected panel are eligible. `hh107` and `hh121` remain development-only but are excluded from parameter estimation because they are two-resident. No untouched home may be added to the fitting set merely to restore a count of 22.
 
 The primary test cohort may be used only for final scoring after the v0.3 candidate is frozen. No parameter, mapping, threshold, state rule, sensor semantic, history length, circadian basis, or model structure may be changed in response to its outcomes.
 
@@ -47,7 +51,7 @@ A defect that makes the frozen candidate scientifically non-executable may be co
 The external study compares, on every eligible primary test home:
 
 - **v0.2 frozen architecture / declared defaults**: the pre-development reference corresponding to the simulator paper architecture;
-- **v0.3 candidate**: the model frozen after development on the 22-home panel and before primary-test scoring.
+- **v0.3 candidate**: the model frozen after development on the already-inspected panel and before primary-test scoring.
 
 A supervised classifier is **not** a primary comparator. It remains a development diagnostic for recoverability and must not be used to tune or select the v0.3 candidate on the primary test cohort.
 
@@ -108,6 +112,7 @@ Before scoring any primary test home, the repository must contain a candidate fr
 - exact activity-mapping table;
 - exact dataset-adapter revision;
 - trainable parameters and the development homes used to estimate them;
+- the complete 22-recording historical development-panel manifest and the 20-home single-resident fitting subset, including the metadata-based exclusions `hh107` and `hh121`;
 - circadian basis/knots or equivalent representation;
 - history-window definition;
 - state ontology;

--- a/scripts/freeze_v03_circadian_profile.py
+++ b/scripts/freeze_v03_circadian_profile.py
@@ -1,9 +1,9 @@
-"""Reconstruct the development cohort and freeze the v0.3 circadian profile.
+"""Reconstruct the development panel and freeze the v0.3 circadian profile.
 
 This script is intentionally outcome-blind. It uses only archive metadata and
-activity annotations from the already-declared development cohort. It never
-runs the behavioural inference model and therefore cannot inspect primary
-external-test outcomes.
+activity annotations from the already-declared development panel. It never runs
+the behavioural inference model and therefore cannot inspect primary external-
+test outcomes.
 """
 
 from __future__ import annotations
@@ -18,7 +18,11 @@ from zoneinfo import ZoneInfo
 from sensor_modeling.datasets import fit_circadian_profile, read_casas_hh
 
 HH_NAME = re.compile(r"^hh\d+.*\.csv$", re.IGNORECASE)
-EXPECTED_DEVELOPMENT_HOMES = 22
+HH_ID = re.compile(r"^(hh\d+)", re.IGNORECASE)
+EXPECTED_PANEL_HOMES = 22
+EXPECTED_FITTING_HOMES = 20
+MULTI_RESIDENT_IDS = frozenset({"hh107", "hh121"})
+EXCLUSION_REASON = "two-resident CASAS metadata"
 DECIMAL_LIMIT = 12_000_000
 BINARY_LIMIT = 12 * 1024 * 1024
 SIZE_RULES = (
@@ -33,6 +37,13 @@ def _sha256(path: Path) -> str:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def _home_id(path: Path) -> str:
+    match = HH_ID.match(path.stem)
+    if match is None:
+        raise ValueError(f"cannot derive hh identifier from {path.name}")
+    return match.group(1).lower()
 
 
 def _candidates(root: Path, limit: int) -> list[Path]:
@@ -53,35 +64,21 @@ def _cohort_key(root: Path, paths: list[Path]) -> tuple[str, ...]:
 def _reconstruct(
     root: Path,
 ) -> tuple[list[Path], str, int, dict[str, dict[str, int]], bool]:
-    """Recover the documented 22-home cohort from metadata only.
-
-    Historical prose says "under 12 MB" but did not retain whether MB meant
-    decimal or MiB. Both conventions are evaluated using file metadata only.
-
-    If exactly one convention yields 22 homes, that convention is recorded. If
-    several conventions yield 22 homes and select the identical files, the
-    cohort is invariant to the ambiguity and the stricter byte limit is used as
-    the effective bound while every equivalent convention is recorded. The
-    function refuses to proceed only when no convention reproduces 22 homes or
-    when equally-sized candidate cohorts genuinely differ.
-    """
+    """Recover the historical 22-recording panel from file metadata only."""
     options = [(name, limit, _candidates(root, limit)) for name, limit in SIZE_RULES]
     evaluation = {
         name: {
             "byte_limit_exclusive": limit,
-            "development_home_count": len(paths),
+            "development_panel_count": len(paths),
         }
         for name, limit, paths in options
     }
-    matches = [
-        item for item in options if len(item[2]) == EXPECTED_DEVELOPMENT_HOMES
-    ]
+    matches = [item for item in options if len(item[2]) == EXPECTED_PANEL_HOMES]
     if not matches:
         counts = {name: len(paths) for name, _, paths in options}
         raise SystemExit(
-            "development cohort reconstruction failed; expected at least one "
-            f"12 MB convention to yield {EXPECTED_DEVELOPMENT_HOMES} homes, "
-            f"got {counts}"
+            "development panel reconstruction failed; expected at least one "
+            f"12 MB convention to yield {EXPECTED_PANEL_HOMES} recordings, got {counts}"
         )
 
     if len(matches) == 1:
@@ -89,12 +86,10 @@ def _reconstruct(
         return paths, name, limit, evaluation, False
 
     reference_key = _cohort_key(root, matches[0][2])
-    if any(
-        _cohort_key(root, paths) != reference_key for _, _, paths in matches[1:]
-    ):
+    if any(_cohort_key(root, paths) != reference_key for _, _, paths in matches[1:]):
         raise SystemExit(
-            "development cohort reconstruction is genuinely ambiguous: multiple "
-            "12 MB conventions yield 22 homes but select different files"
+            "development panel reconstruction is genuinely ambiguous: multiple "
+            "12 MB conventions yield 22 recordings but select different files"
         )
 
     names = [name for name, _, _ in matches]
@@ -111,37 +106,61 @@ def main() -> None:
     parser.add_argument("--fitting-revision", required=True)
     args = parser.parse_args()
 
-    paths, convention, byte_limit, rule_evaluation, invariant = _reconstruct(
+    panel_paths, convention, byte_limit, rule_evaluation, invariant = _reconstruct(
         args.archive_root
     )
+    panel_ids = [_home_id(path) for path in panel_paths]
+    if len(set(panel_ids)) != EXPECTED_PANEL_HOMES:
+        raise SystemExit("development panel does not contain 22 unique hh identifiers")
+    if not MULTI_RESIDENT_IDS <= set(panel_ids):
+        missing = sorted(MULTI_RESIDENT_IDS - set(panel_ids))
+        raise SystemExit(f"expected metadata exclusions are absent from panel: {missing}")
+
+    fitting_paths = [
+        path for path in panel_paths if _home_id(path) not in MULTI_RESIDENT_IDS
+    ]
+    if len(fitting_paths) != EXPECTED_FITTING_HOMES:
+        raise SystemExit(
+            f"expected {EXPECTED_FITTING_HOMES} single-resident fitting homes, "
+            f"got {len(fitting_paths)}"
+        )
+
     zone = ZoneInfo("America/Los_Angeles")
-    recordings = [read_casas_hh(path, timezone=zone) for path in paths]
+    recordings = [read_casas_hh(path, timezone=zone) for path in fitting_paths]
     fit = fit_circadian_profile(recordings)
 
-    homes = [
+    panel_homes = [
         {
-            "id": path.stem,
+            "id": _home_id(path),
             "filename": path.name,
             "bytes": path.stat().st_size,
             "sha256": _sha256(path),
         }
-        for path in paths
+        for path in panel_paths
+    ]
+    fitting_ids = [_home_id(path) for path in fitting_paths]
+    exclusions = [
+        {"id": home_id, "reason": EXCLUSION_REASON}
+        for home_id in sorted(MULTI_RESIDENT_IDS)
     ]
     payload = {
-        "schema_version": 1,
+        "schema_version": 2,
         "status": "frozen-development-fit",
         "candidate": "v0.2 + circadian prior only",
         "source": {
             "provider": "CASAS / Zenodo",
             "record": str(args.source_record),
-            "archive_rule": "single-resident hh CSV under documented 12 MB cutoff",
+            "archive_rule": "historical hh CSV under documented 12 MB cutoff",
             "size_convention": convention,
             "byte_limit_exclusive": byte_limit,
             "size_rule_evaluation": rule_evaluation,
             "cohort_invariant_across_size_conventions": invariant,
         },
-        "development_home_count": len(homes),
-        "development_homes": homes,
+        "development_panel_count": len(panel_homes),
+        "development_panel_homes": panel_homes,
+        "fitting_home_count": len(fitting_ids),
+        "fitting_home_ids": fitting_ids,
+        "fitting_exclusions": exclusions,
         "fitting_revision": args.fitting_revision,
         "fit": fit.to_dict(),
         "profile_sha256": fit.sha256(),
@@ -154,7 +173,11 @@ def main() -> None:
     )
     print(
         json.dumps(
-            {"homes": [row["id"] for row in homes], "profile_sha256": fit.sha256()}
+            {
+                "development_panel_ids": panel_ids,
+                "fitting_home_ids": fitting_ids,
+                "profile_sha256": fit.sha256(),
+            }
         )
     )
 

--- a/scripts/freeze_v03_circadian_profile.py
+++ b/scripts/freeze_v03_circadian_profile.py
@@ -98,6 +98,27 @@ def _reconstruct(
     return matches[0][2], convention, effective_limit, evaluation, True
 
 
+def _select_fitting_paths(panel_paths: list[Path]) -> list[Path]:
+    panel_ids = [_home_id(path) for path in panel_paths]
+    if len(panel_paths) != EXPECTED_PANEL_HOMES or len(set(panel_ids)) != EXPECTED_PANEL_HOMES:
+        raise SystemExit("development panel does not contain 22 unique hh identifiers")
+    if not MULTI_RESIDENT_IDS <= set(panel_ids):
+        missing = sorted(MULTI_RESIDENT_IDS - set(panel_ids))
+        raise SystemExit(
+            f"expected metadata exclusions are absent from panel: {missing}"
+        )
+
+    fitting_paths = [
+        path for path in panel_paths if _home_id(path) not in MULTI_RESIDENT_IDS
+    ]
+    if len(fitting_paths) != EXPECTED_FITTING_HOMES:
+        raise SystemExit(
+            f"expected {EXPECTED_FITTING_HOMES} single-resident fitting homes, "
+            f"got {len(fitting_paths)}"
+        )
+    return fitting_paths
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("archive_root", type=Path)
@@ -109,21 +130,8 @@ def main() -> None:
     panel_paths, convention, byte_limit, rule_evaluation, invariant = _reconstruct(
         args.archive_root
     )
+    fitting_paths = _select_fitting_paths(panel_paths)
     panel_ids = [_home_id(path) for path in panel_paths]
-    if len(set(panel_ids)) != EXPECTED_PANEL_HOMES:
-        raise SystemExit("development panel does not contain 22 unique hh identifiers")
-    if not MULTI_RESIDENT_IDS <= set(panel_ids):
-        missing = sorted(MULTI_RESIDENT_IDS - set(panel_ids))
-        raise SystemExit(f"expected metadata exclusions are absent from panel: {missing}")
-
-    fitting_paths = [
-        path for path in panel_paths if _home_id(path) not in MULTI_RESIDENT_IDS
-    ]
-    if len(fitting_paths) != EXPECTED_FITTING_HOMES:
-        raise SystemExit(
-            f"expected {EXPECTED_FITTING_HOMES} single-resident fitting homes, "
-            f"got {len(fitting_paths)}"
-        )
 
     zone = ZoneInfo("America/Los_Angeles")
     recordings = [read_casas_hh(path, timezone=zone) for path in fitting_paths]

--- a/scripts/validate_v03_profile_freeze.py
+++ b/scripts/validate_v03_profile_freeze.py
@@ -8,7 +8,12 @@ import json
 from pathlib import Path
 
 EXPECTED_CANDIDATE = "v0.2 + circadian prior only"
-EXPECTED_HOME_COUNT = 22
+EXPECTED_PANEL_COUNT = 22
+EXPECTED_FITTING_COUNT = 20
+EXPECTED_EXCLUSIONS = {
+    "hh107": "two-resident CASAS metadata",
+    "hh121": "two-resident CASAS metadata",
+}
 DECIMAL_LIMIT = 12_000_000
 BINARY_LIMIT = 12 * 1024 * 1024
 EXPECTED_PROFILE_STATES = {
@@ -49,11 +54,11 @@ def _validate_size_rule(
         assert evaluation == {
             "decimal_MB": {
                 "byte_limit_exclusive": DECIMAL_LIMIT,
-                "development_home_count": EXPECTED_HOME_COUNT,
+                "development_panel_count": EXPECTED_PANEL_COUNT,
             },
             "binary_MiB": {
                 "byte_limit_exclusive": BINARY_LIMIT,
-                "development_home_count": EXPECTED_HOME_COUNT,
+                "development_panel_count": EXPECTED_PANEL_COUNT,
             },
         }
 
@@ -64,37 +69,57 @@ def _validate_size_rule(
 def validate(
     payload: dict[str, object], *, expected_revision: str | None = None
 ) -> None:
-    assert payload["schema_version"] == 1
+    assert payload["schema_version"] == 2
     assert payload["status"] == "frozen-development-fit"
     assert payload["candidate"] == EXPECTED_CANDIDATE
     assert payload["test_outcomes_inspected"] is False
-    assert payload["development_home_count"] == EXPECTED_HOME_COUNT
+    assert payload["development_panel_count"] == EXPECTED_PANEL_COUNT
+    assert payload["fitting_home_count"] == EXPECTED_FITTING_COUNT
 
-    homes = payload["development_homes"]
-    assert isinstance(homes, list)
-    assert len(homes) == EXPECTED_HOME_COUNT
-    ids = [row["id"] for row in homes]
-    names = [row["filename"] for row in homes]
-    digests = [row["sha256"] for row in homes]
-    assert len(set(ids)) == EXPECTED_HOME_COUNT
-    assert len(set(names)) == EXPECTED_HOME_COUNT
-    assert len(set(digests)) == EXPECTED_HOME_COUNT
-    for row in homes:
+    panel = payload["development_panel_homes"]
+    assert isinstance(panel, list)
+    assert len(panel) == EXPECTED_PANEL_COUNT
+    panel_ids = [row["id"] for row in panel]
+    names = [row["filename"] for row in panel]
+    digests = [row["sha256"] for row in panel]
+    assert len(set(panel_ids)) == EXPECTED_PANEL_COUNT
+    assert len(set(names)) == EXPECTED_PANEL_COUNT
+    assert len(set(digests)) == EXPECTED_PANEL_COUNT
+    for row in panel:
         assert isinstance(row["bytes"], int) and row["bytes"] > 0
         assert isinstance(row["sha256"], str) and len(row["sha256"]) == 64
+
+    fitting_ids = payload["fitting_home_ids"]
+    assert isinstance(fitting_ids, list)
+    assert len(fitting_ids) == EXPECTED_FITTING_COUNT
+    assert len(set(fitting_ids)) == EXPECTED_FITTING_COUNT
+
+    exclusions = payload["fitting_exclusions"]
+    assert isinstance(exclusions, list)
+    exclusion_map = {row["id"]: row["reason"] for row in exclusions}
+    assert exclusion_map == EXPECTED_EXCLUSIONS
+    assert len(exclusions) == len(EXPECTED_EXCLUSIONS)
+
+    panel_set = set(panel_ids)
+    fitting_set = set(fitting_ids)
+    exclusion_set = set(EXPECTED_EXCLUSIONS)
+    assert exclusion_set <= panel_set
+    assert fitting_set <= panel_set
+    assert fitting_set.isdisjoint(exclusion_set)
+    assert fitting_set | exclusion_set == panel_set
 
     source = payload["source"]
     assert isinstance(source, dict)
     assert source["provider"] == "CASAS / Zenodo"
     assert source["record"] == "15708568"
-    _validate_size_rule(source, homes)
+    _validate_size_rule(source, panel)
 
     fit = payload["fit"]
     assert isinstance(fit, dict)
     profile = fit["profile"]
     assert isinstance(profile, dict)
     assert set(profile) == EXPECTED_PROFILE_STATES
-    assert fit["recordings"] == EXPECTED_HOME_COUNT
+    assert fit["recordings"] == EXPECTED_FITTING_COUNT
     assert fit["labelled_seconds"] > 0
     minimum = float(fit["minimum_multiplier"])
     maximum = float(fit["maximum_multiplier"])
@@ -126,7 +151,8 @@ def main() -> None:
                 "valid_v03_profile_freeze": True,
                 "profile_sha256": payload["profile_sha256"],
                 "fitting_revision": payload["fitting_revision"],
-                "development_home_count": payload["development_home_count"],
+                "development_panel_count": payload["development_panel_count"],
+                "fitting_home_count": payload["fitting_home_count"],
             },
             sort_keys=True,
         )

--- a/tests/test_v03_profile_freeze_contract.py
+++ b/tests/test_v03_profile_freeze_contract.py
@@ -1,0 +1,123 @@
+"""Regression tests for the pre-test v0.3 profile-freeze contract."""
+
+from pathlib import Path
+
+import pytest
+
+from scripts.freeze_v03_circadian_profile import _home_id, _select_fitting_paths
+from scripts.validate_v03_profile_freeze import (
+    EXPECTED_EXCLUSIONS,
+    EXPECTED_PROFILE_STATES,
+    _canonical_fit_sha256,
+    validate,
+)
+
+PANEL_IDS = [
+    "hh101",
+    "hh102",
+    "hh103",
+    "hh105",
+    "hh106",
+    "hh107",
+    "hh108",
+    "hh110",
+    "hh111",
+    "hh114",
+    "hh118",
+    "hh119",
+    "hh120",
+    "hh121",
+    "hh122",
+    "hh123",
+    "hh124",
+    "hh125",
+    "hh126",
+    "hh127",
+    "hh129",
+    "hh130",
+]
+
+
+def test_final_fit_excludes_the_two_multi_resident_development_homes() -> None:
+    panel = [Path(f"{home_id}.csv") for home_id in PANEL_IDS]
+    fitting = _select_fitting_paths(panel)
+    fitting_ids = [_home_id(path) for path in fitting]
+
+    assert len(fitting_ids) == 20
+    assert "hh107" not in fitting_ids
+    assert "hh121" not in fitting_ids
+    assert set(fitting_ids) == set(PANEL_IDS) - {"hh107", "hh121"}
+
+
+def test_final_fit_refuses_a_panel_missing_a_metadata_exclusion() -> None:
+    panel_ids = ["hh128" if home_id == "hh121" else home_id for home_id in PANEL_IDS]
+    panel = [Path(f"{home_id}.csv") for home_id in panel_ids]
+
+    with pytest.raises(SystemExit, match="metadata exclusions"):
+        _select_fitting_paths(panel)
+
+
+def _valid_payload() -> dict[str, object]:
+    panel = [
+        {
+            "id": home_id,
+            "filename": f"{home_id}.csv",
+            "bytes": 1_000_000 + index,
+            "sha256": f"{index + 1:064x}",
+        }
+        for index, home_id in enumerate(PANEL_IDS)
+    ]
+    fitting_ids = [
+        home_id for home_id in PANEL_IDS if home_id not in EXPECTED_EXCLUSIONS
+    ]
+    fit = {
+        "profile": {state: [1.0] * 24 for state in EXPECTED_PROFILE_STATES},
+        "recordings": 20,
+        "labelled_seconds": 1.0,
+        "minimum_multiplier": 0.25,
+        "maximum_multiplier": 4.0,
+    }
+    return {
+        "schema_version": 2,
+        "status": "frozen-development-fit",
+        "candidate": "v0.2 + circadian prior only",
+        "source": {
+            "provider": "CASAS / Zenodo",
+            "record": "15708568",
+            "size_convention": "equivalent_decimal_MB_and_binary_MiB",
+            "byte_limit_exclusive": 12_000_000,
+            "size_rule_evaluation": {
+                "decimal_MB": {
+                    "byte_limit_exclusive": 12_000_000,
+                    "development_panel_count": 22,
+                },
+                "binary_MiB": {
+                    "byte_limit_exclusive": 12 * 1024 * 1024,
+                    "development_panel_count": 22,
+                },
+            },
+            "cohort_invariant_across_size_conventions": True,
+        },
+        "development_panel_count": 22,
+        "development_panel_homes": panel,
+        "fitting_home_count": 20,
+        "fitting_home_ids": fitting_ids,
+        "fitting_exclusions": [
+            {"id": home_id, "reason": reason}
+            for home_id, reason in sorted(EXPECTED_EXCLUSIONS.items())
+        ],
+        "fitting_revision": "a" * 40,
+        "fit": fit,
+        "profile_sha256": _canonical_fit_sha256(fit),
+        "test_outcomes_inspected": False,
+    }
+
+
+def test_validator_accepts_only_the_20_home_fitting_partition() -> None:
+    payload = _valid_payload()
+    validate(payload, expected_revision="a" * 40)
+
+    payload["fitting_home_ids"] = list(payload["fitting_home_ids"]) + ["hh107"]
+    payload["fitting_home_count"] = 21
+    with pytest.raises(AssertionError):
+        validate(payload, expected_revision="a" * 40)


### PR DESCRIPTION
Corrects the final v0.3 profile-freeze contract before any primary external-test outcome is inspected.

The first reproducible profile (`e5288794d591c138d29fa6a9543840122a2ea8ca23a01f068fa1b310f0206eeb`) fitted all 22 historically analysed `hh` recordings. CASAS resident-count metadata identify `hh107` and `hh121` as two-resident. That profile is therefore retained only as a reproducibility diagnostic and is explicitly rejected as the immutable single-resident external-validation candidate profile.

This PR keeps the entire 22-recording historical panel development-only, because all 22 had already had outcomes inspected. It does not release `hh107` or `hh121` into the test pool and does not borrow two untouched homes merely to keep a fitting count of 22. Instead, the final circadian parameter fit is prospectively restricted to the 20 single-resident members of the already-inspected panel.

The artifact schema is bumped to v2 and now distinguishes the 22-recording quarantined panel from the 20-home fitting subset, requiring explicit metadata exclusions for `hh107` and `hh121`. The independent validator recomputes the profile hash and enforces that the fitting set plus the two exclusions exactly partitions the historical panel. The canonical workflow now invokes that validator directly. Regression tests pin the selector and validator boundary.

The documentation is corrected at the same time: the external-validation contract no longer incorrectly calls all 22 historical recordings single-resident, and `V03_CANDIDATE_SPECIFICATION.md` now matches the already-frozen #103 primary estimand: the primary summary is the **median** paired household difference, not the mean.

No primary test home has been read, scored, or inspected. No candidate component, circadian estimator, shrinkage parameter, multiplier bound, state mapping, emission parameter, threshold, or external outcome has been changed in response to performance. The correction is driven solely by resident-count metadata and is made before primary scoring.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the final v0.3 circadian-profile freeze so parameter fitting uses only the 20 single-resident home recordings in the already-inspected development panel instead of all 22. CASAS metadata flag `hh107` and `hh121` as two-resident, so they are excluded from the fit; the earlier all-22 profile survives only as a reproducibility diagnostic and is rejected as the immutable candidate.

- The artifact schema is bumped to v2, separating the 22-recording panel from the 20-home fitting subset and recording the two metadata-based exclusions.
- The independent validator recomputes the canonical profile hash and enforces that the fitting set plus the exclusions exactly partition the historical panel.
- The freeze workflow now invokes the validator directly.
- No untouched home is added just to keep the fitting count at 22.
- The external-validation contract and `V03_CANDIDATE_SPECIFICATION.md` now match the already-frozen #103 estimand: the primary summary is the median paired household difference, not the mean.
- Regression tests pin the fitting-subset selector and validator boundary.
- No primary test home has been read, scored, or inspected; the correction is driven solely by resident-count metadata.

<sup>Written for commit 130f418697bc0ef0742fea8fc8818406b60d9bb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

