### PR TITLE
Correct the claim that all 22 homes are single-resident

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -73,8 +73,13 @@ history term the ablation valued at +0.140 is not straightforwardly available to
 a recursive filter, which already carries history in its belief and would
 double-count evidence if given lagged observations as well.
 
-These are single-resident homes from one research group's instrumentation, so
-they are not 22 independent studies, and 0.607 is a ceiling for this
+Two of the 22, `hh107` and `hh121`, are two-occupant recordings by CASAS
+metadata, and every figure here was computed before that was noticed. Excluding
+them changes the medians by less than a thousandth, but the ontology models one
+resident, and `hh107`'s anomalous behaviour was a clue that went unexamined.
+
+The remaining homes are from one research group's instrumentation, so they are
+not 22 independent studies, and 0.607 is a ceiling for this
 instrumentation rather than for ambient sensing generally. The gap between 0.420
 and what is recoverable is real nonetheless.
 

--- a/docs/real_data.md
+++ b/docs/real_data.md
@@ -584,11 +584,27 @@ of the three.
 ## Status
 
 The adapters are implemented and tested, and 22 real homes have been scored.
-What has **not** been done: any dataset other than CASAS, any fitting of
-parameters to real data, and any paired comparison of the kind the simulator
-experiments use. These are all single-resident homes from one research group's
-instrumentation, so they are not independent of each other in the way 22
-households from different studies would be.
+What has **not** been done: any dataset other than CASAS, any paired comparison
+of the kind the simulator experiments use, and any evaluation on a cohort held
+back from every earlier experiment.
+
+**Two of the 22 are not single-resident.** CASAS resident-count metadata
+identify `hh107` and `hh121` as two-occupant recordings. Every figure on this
+page was computed over all 22 before that was noticed, which matters because the
+ontology models one monitored resident and treats other people as
+unattributable ambient activity.
+
+The headline numbers are unaffected: excluding both leaves median balanced
+accuracy at 0.420 and median calibration error at 0.314, unchanged to three
+decimals. But the omission left a clue unexamined. `hh107` had the worst
+calibration of any home at 0.517, and was the single largest outlier in the
+rate-fitting experiment, moving 0.379 to 0.549 where every other home moved by
+a fraction of that. A second unmodelled resident is a plausible explanation for
+both, and it was not investigated at the time.
+
+The remaining caveat still stands: these are homes from one research group's
+instrumentation, so they are not independent in the way 22 households from
+different studies would be.
 
 The obvious next steps are refitting emissions from a subset of homes and
 scoring on held-out ones, and checking whether the `home_inactive`/`away`


### PR DESCRIPTION
`real_data.md` states "These are all single-resident homes". #122 establishes that is false: CASAS resident-count metadata identify `hh107` and `hh121` as two-occupant recordings, and every figure on the page was computed over all 22 before that was noticed.

The headline numbers survive. Excluding both leaves median balanced accuracy at 0.420 and median calibration error at 0.314, unchanged to three decimals.

What did not survive is the claim itself, and a missed signal. `hh107` had the worst calibration of any home at 0.517 and was the largest outlier in the rate-fitting experiment, moving 0.379 to 0.549 where other homes moved by a fraction of that. A second unmodelled resident plausibly explains both, and it was recorded as an anomaly rather than investigated. The page now says so.

This corrects the documentation only. The freeze correction is #122's.