### PR TITLE
Format the corrected v0.3 freezer

### DIFF
--- a/scripts/freeze_v03_circadian_profile.py
+++ b/scripts/freeze_v03_circadian_profile.py
@@ -100,7 +100,10 @@ def _reconstruct(
 
 def _select_fitting_paths(panel_paths: list[Path]) -> list[Path]:
     panel_ids = [_home_id(path) for path in panel_paths]
-    if len(panel_paths) != EXPECTED_PANEL_HOMES or len(set(panel_ids)) != EXPECTED_PANEL_HOMES:
+    if (
+        len(panel_paths) != EXPECTED_PANEL_HOMES
+        or len(set(panel_ids)) != EXPECTED_PANEL_HOMES
+    ):
         raise SystemExit("development panel does not contain 22 unique hh identifiers")
     if not MULTI_RESIDENT_IDS <= set(panel_ids):
         missing = sorted(MULTI_RESIDENT_IDS - set(panel_ids))


### PR DESCRIPTION
Formatter-only follow-up to #122. The merged design correction is scientifically unchanged; this PR applies the repository's pinned Black 23.9.1 formatting to the single 91-character condition in `scripts/freeze_v03_circadian_profile.py`. No cohort membership, exclusion rule, schema, validator behaviour, fitting estimator, parameter, or external-validation decision changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies Black 23.9.1 formatting to the corrected v0.3 freezer condition in `scripts/freeze_v03_circadian_profile.py`; the change is formatter-only and does not alter any behavior or decisions.

<sup>Written for commit 013f325e33df2d8b0f088851fd6ab94987a2a1eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

