### PR TITLE
Freeze the v0.3 external sampling frame

### DIFF
--- a/artifacts/v03/casas_v1_resident_registry.json
+++ b/artifacts/v03/casas_v1_resident_registry.json
@@ -1,0 +1,53 @@
+{
+  "source": {
+    "provider": "Zenodo",
+    "record": "15708568",
+    "doi": "10.5281/zenodo.15708568",
+    "release_version": "v1",
+    "published": "2025-06-20",
+    "archive": "labeled_data.zip",
+    "archive_bytes": 236037656,
+    "archive_checksum": "md5:ec37d679e85a6ae39e84994888afd514"
+  },
+  "single_resident_home_ids": [
+    "aruba",
+    "hh101", "hh102", "hh103", "hh104", "hh105", "hh106", "hh108", "hh109", "hh110", "hh111", "hh112", "hh113", "hh114", "hh115", "hh116", "hh117", "hh118", "hh119", "hh120", "hh122", "hh123", "hh124", "hh125", "hh126", "hh127", "hh128", "hh129", "hh130",
+    "ihs07", "ihs11", "ihs12", "ihs21", "ihs28", "ihs35", "ihs37", "ihs38", "ihs40", "ihs58", "ihs59", "ihs68", "ihs70", "ihs75", "ihs80", "ihs84", "ihs85", "ihs95", "ihs96", "ihs107", "ihs108", "ihs114", "ihs118",
+    "mn57", "mn77", "mn82", "mn85",
+    "mv101",
+    "navan",
+    "rw101", "rw103", "rw105", "rw106", "rw107",
+    "tm001", "tm002", "tm003", "tm005", "tm006", "tm007", "tm008", "tm009", "tm010", "tm011", "tm013", "tm014", "tm015", "tm016", "tm017", "tm018", "tm019", "tm020", "tm021", "tm022", "tm026", "tm029", "tm032", "tm035", "tm036", "tm037", "tm038", "tm039", "tm040", "tm041", "tm042", "tm043"
+  ],
+  "two_resident_home_ids": [
+    "hh107", "hh121",
+    "ihs06", "ihs08", "ihs09", "ihs22", "ihs25", "ihs60", "ihs98", "ihs100", "ihs101", "ihs104", "ihs115", "ihs116", "ihs117", "ihs121",
+    "kyoto10", "kyoto11", "kyoto12", "kyoto13", "kyoto14", "kyoto15", "kyoto16", "kyoto17", "kyoto18", "kyoto19", "kyoto20", "kyoto21",
+    "milan",
+    "mn50", "mn62", "mn64", "mn79", "mn83", "mn86",
+    "rw104", "rw110",
+    "tm004", "tm024", "tm027", "tm030", "tm033",
+    "tulum"
+  ],
+  "more_than_two_resident_home_ids": [
+    "cairo",
+    "ihs14", "ihs31", "ihs93", "ihs99", "ihs109", "ihs119", "ihs120", "ihs123", "ihs124", "ihs125",
+    "laval",
+    "mn33", "mn51", "mn58", "mn59", "mn61", "mn71", "mn73", "mn76",
+    "paris"
+  ],
+  "unknown_resident_home_ids": [
+    "atmo1", "atmo2", "atmo4", "atmo6", "atmo7", "atmo8", "atmo9", "atmo10",
+    "mva001", "mva002",
+    "shib003", "shib004", "shib005", "shib006", "shib007", "shib008", "shib009", "shib010", "shib011", "shib012", "shib013", "shib014", "shib015", "shib016", "shib017", "shib018", "shib019", "shib020", "shib021", "shib022", "shib023", "shib024", "shiblsdf"
+  ],
+  "development_only_home_ids": [
+    "hh101", "hh102", "hh103", "hh105", "hh106", "hh107", "hh108", "hh110", "hh111", "hh114", "hh118", "hh119", "hh120", "hh121", "hh122", "hh123", "hh124", "hh125", "hh126", "hh127", "hh129", "hh130"
+  ],
+  "notes": [
+    "Resident counts are transcribed from the published Zenodo record metadata before primary external scoring.",
+    "Unknown resident count is not treated as single resident.",
+    "The 22 development-only homes remain excluded from the primary cohort regardless of resident count because their outcomes were previously inspected.",
+    "Archive membership and parser/mapping eligibility are separate prospective filters and are not encoded by this registry."
+  ]
+}

--- a/docs/V03_EXTERNAL_SAMPLING_FRAME.md
+++ b/docs/V03_EXTERNAL_SAMPLING_FRAME.md
@@ -1,0 +1,74 @@
+# v0.3 external sampling frame
+
+Status: **prospectively frozen before primary external scoring or test-home enumeration**.
+
+This document narrows the external-validation sampling frame to one finite public release so the eligible cohort cannot later expand or contract opportunistically.
+
+## Frozen source frame
+
+Only homes contained in **CASAS Smart Home dataset v1**, Zenodo record `15708568`, file `labeled_data.zip`, are eligible for the primary v0.3 external-validation cohort.
+
+Frozen source identity:
+
+- DOI: `10.5281/zenodo.15708568`
+- release: `v1`
+- published: `2025-06-20`
+- archive: `labeled_data.zip`
+- archive size: `236037656` bytes
+- archive checksum: `md5:ec37d679e85a6ae39e84994888afd514`
+
+Later CASAS records, companion releases, replacements, corrections, or additional public CASAS recordings are outside the primary sampling frame. They may support later replication but cannot be added to this one-shot primary cohort.
+
+## Resident-count gate
+
+Resident count is taken only from the published Zenodo record metadata and is frozen in `artifacts/v03/casas_v1_resident_registry.json`.
+
+A primary candidate must be explicitly listed as **one resident**. Two-resident, >2-resident, and unknown-resident homes are ineligible. Resident count is never inferred from filename, floor plan, activity labels, sensor behaviour, or model output.
+
+## Development firewall
+
+The full 22-recording historical `hh` panel remains development-only regardless of current eligibility metadata. Previous outcome inspection is sufficient for exclusion.
+
+Therefore the primary cohort is selected as
+
+\[
+\mathcal T
+=\mathcal L\cap\mathcal R_1\cap\mathcal E\setminus\mathcal D,
+\]
+
+where
+
+- \(\mathcal L\) is exact membership in the frozen `labeled_data.zip` archive;
+- \(\mathcal R_1\) is the published one-resident registry;
+- \(\mathcal E\) is prospective parser/mapping eligibility under the frozen external-validation contract;
+- \(\mathcal D\) is the complete 22-home development panel.
+
+No model prediction, accuracy, calibration statistic, state recall, or v0.2/v0.3 comparison may be used to define any of these sets.
+
+## Remaining prospective eligibility audit
+
+For each archive member in \(\mathcal L\cap\mathcal R_1\setminus\mathcal D\), the pre-scoring audit must record:
+
+1. raw archive path, byte size, and SHA-256;
+2. home identifier and resident-count registry match;
+3. source format and the exact frozen adapter used;
+4. whether timestamps can be resolved without guessing;
+5. whether motion and/or door events can be represented under existing observation semantics;
+6. the set of prospectively mapped behavioural states represented by annotations;
+7. whether at least five of the seven frozen states are represented;
+8. whether mapped labelled coverage is non-zero;
+9. any parser/provenance defect and its disposition.
+
+This audit may inspect raw sensor rows and annotation semantics. It may not instantiate the behavioural inference model, produce state predictions, or compute evaluation metrics.
+
+## Cohort freeze
+
+The complete eligible-home manifest and raw-file checksums must be committed and pass CI before any primary scoring begins. Once that manifest is frozen, there is no performance-based home removal, replacement, or addition.
+
+The statistical unit remains the home, and the one-shot primary estimand remains the median paired household difference
+
+\[
+D_h=B_h^{(0.3)}-B_h^{(0.2)}.
+\]
+
+Nothing in this sampling-frame freeze changes the already frozen model, profile, mapping principles, metric definitions, or analysis plan.


### PR DESCRIPTION
Freezes the primary external-validation sampling frame before any test-home enumeration or scoring.

The primary source frame is now exactly CASAS Smart Home dataset v1, Zenodo record `15708568`, file `labeled_data.zip` (`236037656` bytes, `md5:ec37d679e85a6ae39e84994888afd514`). Later CASAS companion releases or other public CASAS recordings are outside this one-shot primary frame and may only support later replication.

This PR also freezes the published resident-count registry from the Zenodo metadata. A primary candidate must be explicitly listed as one resident; two-resident, >2-resident, and unknown-resident homes are ineligible. Resident count is never inferred from filename or sensor/activity behaviour.

The historical 22-home `hh` panel remains development-only regardless of resident count because its outcomes were previously inspected.

The primary cohort is prospectively defined as:

`archive membership ∩ published single-resident registry ∩ parser/mapping eligibility − 22-home development panel`.

The remaining eligibility audit may inspect raw rows and annotation semantics, but may not instantiate the behavioural inference model, generate state predictions, or compute any performance metric. The exact eligible-home manifest and raw-file checksums must be committed and pass CI before primary scoring.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Freezes the v0.3 primary external-validation sampling frame to one published CASAS release before any test-home enumeration or scoring, so the eligible cohort can no longer expand or contract. Later CASAS releases are outside this one-shot frame and may only support replication.

- Primary source frame is CASAS Smart Home dataset v1, Zenodo record `15708568`, file `labeled_data.zip`, with published size and md5 checksum pinned.
- Resident count comes only from published Zenodo metadata; only explicitly single-resident homes are eligible.
- The 22-home `hh` development panel stays development-only regardless of resident count.
- The remaining eligibility audit may inspect raw rows and annotation semantics but may not instantiate the inference model or compute any metric.
- The eligible-home manifest and raw-file checksums must be committed and pass CI before primary scoring begins.

<sup>Written for commit fecb4d8768df2bc2ee2d712bb56f29efe4f730a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

