### PR TITLE
Freeze the pre-scoring external archive inventory audit

### DIFF
--- a/scripts/inventory_v03_external_archive.py
+++ b/scripts/inventory_v03_external_archive.py
@@ -1,0 +1,178 @@
+"""Inventory the frozen CASAS external-validation archive without model inference.
+
+This script is deliberately limited to archive/file metadata and raw text
+semantics. It must not import the behavioural inference or evaluation stack.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from collections import Counter
+from pathlib import Path
+
+_TIMESTAMP = re.compile(
+    r"^\s*(\d{4}-\d{2}-\d{2})[\s,]+(\d{2}:\d{2}:\d{2}(?:\.\d+)?)"
+)
+_MARKER = re.compile(r'([A-Za-z][A-Za-z0-9_]*)\s*=\s*"?(begin|end)"?', re.I)
+_TOKEN = re.compile(r"[A-Za-z0-9]+")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _normalise(value: str) -> str:
+    return "".join(_TOKEN.findall(value.lower()))
+
+
+def _home_matches(path: Path, known_ids: set[str]) -> list[str]:
+    """Return resident-registry IDs explicitly represented in a path component."""
+    components = [path.stem, *path.parts[:-1]]
+    normalised = {_normalise(component) for component in components if component}
+    return sorted(home_id for home_id in known_ids if _normalise(home_id) in normalised)
+
+
+def _delimiter(line: str) -> str:
+    if "," in line:
+        return "comma"
+    if "\t" in line:
+        return "tab"
+    return "whitespace"
+
+
+def _inspect_text(path: Path, max_lines: int = 5000) -> dict[str, object]:
+    """Inspect raw syntax only; never instantiate a dataset adapter or model."""
+    delimiters: Counter[str] = Counter()
+    labels: Counter[str] = Counter()
+    timestamp_rows = 0
+    nonempty_rows = 0
+    first_timestamp = None
+    last_timestamp = None
+
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        for index, raw in enumerate(handle):
+            if index >= max_lines:
+                break
+            line = raw.strip()
+            if not line:
+                continue
+            nonempty_rows += 1
+            delimiters[_delimiter(raw)] += 1
+            stamp = _TIMESTAMP.match(raw)
+            if stamp is not None:
+                timestamp_rows += 1
+                value = f"{stamp.group(1)} {stamp.group(2)}"
+                if first_timestamp is None:
+                    first_timestamp = value
+                last_timestamp = value
+            for match in _MARKER.finditer(raw):
+                labels[match.group(1)] += 1
+
+    return {
+        "sampled_nonempty_rows": nonempty_rows,
+        "timestamp_parseable_rows": timestamp_rows,
+        "timestamp_parseable_fraction": (
+            timestamp_rows / nonempty_rows if nonempty_rows else 0.0
+        ),
+        "first_sampled_timestamp": first_timestamp,
+        "last_sampled_timestamp": last_timestamp,
+        "delimiter_counts": dict(sorted(delimiters.items())),
+        "annotation_marker_labels": dict(sorted(labels.items())),
+    }
+
+
+def build_inventory(archive_root: Path, registry: dict[str, object]) -> dict[str, object]:
+    singles = set(registry["single_resident_home_ids"])
+    development = set(registry["development_only_home_ids"])
+    candidates = singles - development
+    known = (
+        singles
+        | set(registry["two_resident_home_ids"])
+        | set(registry["more_than_two_resident_home_ids"])
+        | set(registry["unknown_resident_home_ids"])
+    )
+
+    by_home: dict[str, list[dict[str, object]]] = {home_id: [] for home_id in candidates}
+    ambiguous_paths: list[dict[str, object]] = []
+
+    for path in sorted(p for p in archive_root.rglob("*") if p.is_file()):
+        matches = _home_matches(path.relative_to(archive_root), known)
+        if len(matches) > 1:
+            ambiguous_paths.append(
+                {"path": path.relative_to(archive_root).as_posix(), "matches": matches}
+            )
+            continue
+        if len(matches) != 1 or matches[0] not in candidates:
+            continue
+
+        entry: dict[str, object] = {
+            "path": path.relative_to(archive_root).as_posix(),
+            "bytes": path.stat().st_size,
+            "sha256": _sha256(path),
+        }
+        try:
+            entry["raw_text_audit"] = _inspect_text(path)
+        except OSError as exc:
+            entry["raw_text_audit_error"] = type(exc).__name__
+        by_home[matches[0]].append(entry)
+
+    homes = [
+        {
+            "home_id": home_id,
+            "resident_count": 1,
+            "development_only": False,
+            "files": by_home[home_id],
+            "archive_member_found": bool(by_home[home_id]),
+        }
+        for home_id in sorted(candidates)
+    ]
+
+    return {
+        "schema_version": 1,
+        "status": "prediction-free-archive-inventory",
+        "source": registry["source"],
+        "selection_stage": "inventory_only_not_final_eligibility",
+        "model_inference_performed": False,
+        "performance_metrics_computed": False,
+        "candidate_registry_count": len(candidates),
+        "homes": homes,
+        "ambiguous_paths": ambiguous_paths,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("archive_root", type=Path)
+    parser.add_argument("registry", type=Path)
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+
+    registry = json.loads(args.registry.read_text(encoding="utf-8"))
+    payload = build_inventory(args.archive_root, registry)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    print(
+        json.dumps(
+            {
+                "candidate_registry_count": payload["candidate_registry_count"],
+                "archive_members_found": sum(
+                    bool(home["archive_member_found"]) for home in payload["homes"]
+                ),
+                "ambiguous_paths": len(payload["ambiguous_paths"]),
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/inventory_v03_external_archive.py
+++ b/scripts/inventory_v03_external_archive.py
@@ -36,7 +36,9 @@ def _home_matches(path: Path, known_ids: set[str]) -> list[str]:
     """Return resident-registry IDs explicitly represented in a path component."""
     components = [path.stem, *path.parts[:-1]]
     normalised = {_normalise(component) for component in components if component}
-    return sorted(home_id for home_id in known_ids if _normalise(home_id) in normalised)
+    return sorted(
+        home_id for home_id in known_ids if _normalise(home_id) in normalised
+    )
 
 
 def _delimiter(line: str) -> str:
@@ -88,7 +90,9 @@ def _inspect_text(path: Path, max_lines: int = 5000) -> dict[str, object]:
     }
 
 
-def build_inventory(archive_root: Path, registry: dict[str, object]) -> dict[str, object]:
+def build_inventory(
+    archive_root: Path, registry: dict[str, object]
+) -> dict[str, object]:
     singles = set(registry["single_resident_home_ids"])
     development = set(registry["development_only_home_ids"])
     candidates = singles - development
@@ -99,14 +103,19 @@ def build_inventory(archive_root: Path, registry: dict[str, object]) -> dict[str
         | set(registry["unknown_resident_home_ids"])
     )
 
-    by_home: dict[str, list[dict[str, object]]] = {home_id: [] for home_id in candidates}
+    by_home: dict[str, list[dict[str, object]]] = {
+        home_id: [] for home_id in candidates
+    }
     ambiguous_paths: list[dict[str, object]] = []
 
     for path in sorted(p for p in archive_root.rglob("*") if p.is_file()):
         matches = _home_matches(path.relative_to(archive_root), known)
         if len(matches) > 1:
             ambiguous_paths.append(
-                {"path": path.relative_to(archive_root).as_posix(), "matches": matches}
+                {
+                    "path": path.relative_to(archive_root).as_posix(),
+                    "matches": matches,
+                }
             )
             continue
         if len(matches) != 1 or matches[0] not in candidates:

--- a/tests/test_v03_external_archive_inventory.py
+++ b/tests/test_v03_external_archive_inventory.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).parents[1] / "scripts" / "inventory_v03_external_archive.py"
+spec = importlib.util.spec_from_file_location("inventory_v03_external_archive", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+inventory = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(inventory)
+
+
+def _registry() -> dict[str, object]:
+    return {
+        "source": {"record": "15708568", "archive": "labeled_data.zip"},
+        "single_resident_home_ids": ["hh101", "hh104", "aruba"],
+        "two_resident_home_ids": ["hh107"],
+        "more_than_two_resident_home_ids": ["cairo"],
+        "unknown_resident_home_ids": ["mva001"],
+        "development_only_home_ids": ["hh101"],
+    }
+
+
+def test_inventory_excludes_development_and_hashes_candidates(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    (root / "hh104").mkdir(parents=True)
+    (root / "hh101").mkdir(parents=True)
+    (root / "hh104" / "hh104.csv").write_text(
+        '2011-01-01,00:00:00.000001,Kitchen,ON,Cook="begin"\n',
+        encoding="utf-8",
+    )
+    (root / "hh101" / "hh101.csv").write_text(
+        '2011-01-01,00:00:00.000001,Kitchen,ON,Cook="begin"\n',
+        encoding="utf-8",
+    )
+
+    payload = inventory.build_inventory(root, _registry())
+    homes = {row["home_id"]: row for row in payload["homes"]}
+
+    assert set(homes) == {"aruba", "hh104"}
+    assert homes["hh104"]["archive_member_found"] is True
+    assert homes["hh104"]["files"][0]["sha256"]
+    assert homes["hh104"]["files"][0]["raw_text_audit"][
+        "annotation_marker_labels"
+    ] == {"Cook": 1}
+    assert homes["aruba"]["archive_member_found"] is False
+    assert payload["model_inference_performed"] is False
+    assert payload["performance_metrics_computed"] is False
+
+
+def test_home_matching_requires_explicit_path_component(tmp_path: Path) -> None:
+    path = Path("root/not-hh104-ish/data.csv")
+    assert inventory._home_matches(path, {"hh104"}) == []
+    assert inventory._home_matches(Path("root/hh104/data.csv"), {"hh104"}) == ["hh104"]
+
+
+def test_output_is_json_serialisable(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    root.mkdir()
+    payload = inventory.build_inventory(root, _registry())
+    json.dumps(payload, allow_nan=False)

--- a/tests/test_v03_external_archive_inventory.py
+++ b/tests/test_v03_external_archive_inventory.py
@@ -1,15 +1,9 @@
 from __future__ import annotations
 
-import importlib.util
 import json
 from pathlib import Path
 
-
-MODULE_PATH = Path(__file__).parents[1] / "scripts" / "inventory_v03_external_archive.py"
-spec = importlib.util.spec_from_file_location("inventory_v03_external_archive", MODULE_PATH)
-assert spec is not None and spec.loader is not None
-inventory = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(inventory)
+from scripts import inventory_v03_external_archive as inventory
 
 
 def _registry() -> dict[str, object]:
@@ -50,10 +44,12 @@ def test_inventory_excludes_development_and_hashes_candidates(tmp_path: Path) ->
     assert payload["performance_metrics_computed"] is False
 
 
-def test_home_matching_requires_explicit_path_component(tmp_path: Path) -> None:
+def test_home_matching_requires_explicit_path_component() -> None:
     path = Path("root/not-hh104-ish/data.csv")
     assert inventory._home_matches(path, {"hh104"}) == []
-    assert inventory._home_matches(Path("root/hh104/data.csv"), {"hh104"}) == ["hh104"]
+    assert inventory._home_matches(Path("root/hh104/data.csv"), {"hh104"}) == [
+        "hh104"
+    ]
 
 
 def test_output_is_json_serialisable(tmp_path: Path) -> None:


### PR DESCRIPTION
Adds the prospectively defined, prediction-free inventory program for the frozen CASAS v1 external sampling frame.

The program intersects the published single-resident registry with the permanent 22-home development firewall, then inventories matching archive files by explicit path-component identity. For each candidate file it records relative path, bytes, SHA-256, sampled delimiter/timestamp syntax and annotation-marker vocabulary. It does not import the behavioural inference/evaluation stack, generate state predictions, or compute performance metrics.

This is intentionally an inventory stage, not the final eligibility decision. Parser/timezone/mapping eligibility will be resolved prospectively from these raw-format facts and frozen before scoring. Regression tests verify that development homes cannot enter the candidate inventory, home IDs are not inferred from loose substrings, candidate files are hashed, and the output explicitly records that inference and metrics were not performed.

No primary external-test model output has been generated or inspected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a prediction-free inventory script for the frozen CASAS v1 external sampling frame, so the archive can be audited without running model inference or computing performance metrics.

- Single-resident homes are intersected with the development firewall before matching, so development homes cannot enter the candidate inventory.
- Candidate files are matched by explicit path-component identity, then hashed and inspected for raw delimiter/timestamp syntax and annotation-marker vocabulary.
- Output records `model_inference_performed: false` and `performance_metrics_computed: false` with a `selection_stage` of `inventory_only_not_final_eligibility`.
- Tests pin the contract: development-home exclusion, explicit matching, hashing, and JSON serializability.

<sup>Written for commit 6d2e5f9f663e5391137102d38a054bcd2bdd9e90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

