### PR TITLE
Read cohort eligibility from the resident registry

### DIFF
--- a/artifacts/v03/external_cohort_manifest_draft.json
+++ b/artifacts/v03/external_cohort_manifest_draft.json
@@ -985,7 +985,7 @@
       "unmapped_locations": []
     }
   ],
-  "note": "Screened with the extended location normaliser. Every exclusion is now a contract criterion, not a parser defect. Not frozen: freezing the cohort is a deliberate act taken before scoring.",
+  "note": "Eligibility read from the resident registry rather than an inline copy. Every exclusion is a contract criterion; none is a parser defect. Not frozen: freezing the cohort is a deliberate act taken before scoring.",
   "purpose": "external-validation primary test cohort",
   "schema_version": 1,
   "scored": false,
@@ -2249,7 +2249,17 @@
   "source": {
     "provider": "CASAS / Zenodo",
     "record": "15708568",
-    "resident_counts": "Zenodo record description for the same record"
+    "registry_source": {
+      "archive": "labeled_data.zip",
+      "archive_bytes": 236037656,
+      "archive_checksum": "md5:ec37d679e85a6ae39e84994888afd514",
+      "doi": "10.5281/zenodo.15708568",
+      "provider": "Zenodo",
+      "published": "2025-06-20",
+      "record": "15708568",
+      "release_version": "v1"
+    },
+    "resident_counts": "artifacts/v03/casas_v1_resident_registry.json"
   },
   "status": "draft-not-frozen"
 }

--- a/scripts/build_external_cohort_manifest.py
+++ b/scripts/build_external_cohort_manifest.py
@@ -25,81 +25,28 @@ from zoneinfo import ZoneInfo
 
 from sensor_modeling.datasets import read_casas_hh
 
-#: Recordings the development panel already consumed. Permanently ineligible:
-#: their outcomes were inspected, which is sufficient to make them development
-#: data regardless of resident count.
-DEVELOPMENT_PANEL = frozenset(
-    f"hh{n}"
-    for n in [
-        101,
-        102,
-        103,
-        105,
-        106,
-        107,
-        108,
-        110,
-        111,
-        114,
-        118,
-        119,
-        120,
-        121,
-        122,
-        123,
-        124,
-        125,
-        126,
-        127,
-        129,
-        130,
-    ]
-)
+#: Machine-readable resident counts and development panel.
+#:
+#: Read rather than transcribed. An inline copy of the Zenodo table was a second
+#: source of truth for the same facts, and a second source of truth drifts: the
+#: transcription was already missing two single-resident homes when the registry
+#: was compared against it.
+REGISTRY_PATH = Path("artifacts/v03/casas_v1_resident_registry.json")
 
-#: Single-resident homes, transcribed from the Zenodo record description for
-#: record 15708568. Only families present in ``labeled_data.zip`` are listed.
-SINGLE_RESIDENT = frozenset(
-    [
-        f"hh{n}"
-        for n in list(range(101, 107)) + list(range(108, 121)) + list(range(122, 131))
-    ]
-    + ["rw101", "rw103", "rw105", "rw106", "rw107"]
-    + ["mv101"]
-    + [
-        f"tm{n:03d}"
-        for n in list(range(1, 4))
-        + list(range(5, 12))
-        + list(range(13, 23))
-        + [26, 29, 32]
-        + list(range(35, 44))
-    ]
-    + [
-        "ihs07",
-        "ihs11",
-        "ihs12",
-        "ihs21",
-        "ihs28",
-        "ihs35",
-        "ihs37",
-        "ihs38",
-        "ihs40",
-        "ihs58",
-        "ihs59",
-        "ihs68",
-        "ihs70",
-        "ihs75",
-        "ihs80",
-        "ihs84",
-        "ihs85",
-        "ihs95",
-        "ihs96",
-        "ihs107",
-        "ihs108",
-        "ihs114",
-        "ihs118",
-    ]
-    + ["mn57", "mn77", "mn82", "mn85"]
-)
+
+def load_registry(
+    path: Path,
+) -> tuple[frozenset[str], frozenset[str], dict[str, object]]:
+    """Return the development panel, single-resident ids, and provenance."""
+    if not path.exists():
+        raise SystemExit(f"resident registry not found at {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    panel = frozenset(payload["development_only_home_ids"])
+    single = frozenset(payload["single_resident_home_ids"])
+    if not panel or not single:
+        raise SystemExit("resident registry is missing required id lists")
+    return panel, single, payload.get("source", {})
+
 
 #: The contract requires at least five of the seven frozen states to be mappable.
 MINIMUM_MAPPED_STATES = 5
@@ -115,7 +62,12 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
-def screen(path: Path, zone: ZoneInfo) -> dict[str, object]:
+def screen(
+    path: Path,
+    zone: ZoneInfo,
+    panel: frozenset[str],
+    single_resident: frozenset[str],
+) -> dict[str, object]:
     """Apply the contract's eligibility criteria to one recording.
 
     Returns the verdict and the evidence for it, including the reason for any
@@ -130,10 +82,10 @@ def screen(path: Path, zone: ZoneInfo) -> dict[str, object]:
         "sha256": _sha256(path),
     }
 
-    if home in DEVELOPMENT_PANEL:
+    if home in panel:
         row.update(eligible=False, reason="development panel; outcomes inspected")
         return row
-    if home not in SINGLE_RESIDENT:
+    if home not in single_resident:
         row.update(eligible=False, reason="not single-resident by Zenodo metadata")
         return row
 
@@ -174,8 +126,10 @@ def main() -> None:
     parser.add_argument("output", type=Path)
     parser.add_argument("--timezone", default="America/Los_Angeles")
     parser.add_argument("--source-record", default="15708568")
+    parser.add_argument("--registry", type=Path, default=REGISTRY_PATH)
     args = parser.parse_args()
 
+    panel, single_resident, registry_source = load_registry(args.registry)
     zone = ZoneInfo(args.timezone)
     paths = sorted(
         (p for p in args.archive_root.rglob("*.csv") if NAME.match(p.name)),
@@ -184,7 +138,7 @@ def main() -> None:
     if not paths:
         raise SystemExit(f"no candidate recordings found under {args.archive_root}")
 
-    screened = [screen(path, zone) for path in paths]
+    screened = [screen(path, zone, panel, single_resident) for path in paths]
     eligible = [row for row in screened if row["eligible"]]
 
     manifest = {
@@ -195,7 +149,8 @@ def main() -> None:
         "source": {
             "provider": "CASAS / Zenodo",
             "record": args.source_record,
-            "resident_counts": "Zenodo record description for the same record",
+            "resident_counts": "artifacts/v03/casas_v1_resident_registry.json",
+            "registry_source": registry_source,
         },
         "criteria": {
             "outside_development_panel": True,
@@ -205,7 +160,7 @@ def main() -> None:
             "non_zero_labelled_coverage": True,
             "size_cutoff": None,
         },
-        "development_panel": sorted(DEVELOPMENT_PANEL),
+        "development_panel": sorted(panel),
         "eligible_count": len(eligible),
         "eligible_homes": eligible,
         "screened": screened,

--- a/tests/test_casas_hh.py
+++ b/tests/test_casas_hh.py
@@ -314,3 +314,28 @@ class TestExtendedLocationVocabulary:
         """Existing names keep their explicit mapping rather than being parsed."""
         assert normalise_location("OutsideDoor") == HH_LOCATIONS["OutsideDoor"]
         assert normalise_location("LoungeChair") == HH_LOCATIONS["LoungeChair"]
+
+
+def test_the_cohort_screener_reads_the_resident_registry() -> None:
+    """Eligibility must come from the registry, not a transcribed copy.
+
+    An inline copy of the Zenodo resident table was a second source of truth for
+    the same facts. It had already drifted: two single-resident homes present in
+    the registry were missing from the transcription.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    spec = importlib.util.spec_from_file_location(
+        "cohort", Path("scripts/build_external_cohort_manifest.py")
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    panel, single, source = module.load_registry(module.REGISTRY_PATH)
+
+    assert len(panel) == 22
+    assert "hh107" not in single and "hh121" not in single
+    assert "hh104" in single
+    assert source.get("record") == "15708568"

--- a/tests/test_missing_data.py
+++ b/tests/test_missing_data.py
@@ -1,4 +1,5 @@
 """Tests for missing-data utilities."""
+
 import pandas as pd
 
 from sensor_modeling.utils import (

--- a/tests/test_nhpp_utils.py
+++ b/tests/test_nhpp_utils.py
@@ -1,4 +1,5 @@
 """Tests for NHPP-PELT utilities."""
+
 import json
 
 import numpy as np


### PR DESCRIPTION
The cohort screener carried an inline transcription of the Zenodo resident table. `artifacts/v03/casas_v1_resident_registry.json` now holds the same facts machine-readably, so there were two sources of truth for the same thing.

They had already diverged. The registry lists 95 single-resident homes; my transcription had 93, missing `aruba` and `navan`. Neither appears in `labeled_data.zip`, so the cohort is unchanged at 43 homes — but the drift happened within an hour of the transcription being written, which is the argument for not keeping one.

The screener now loads the registry and takes the panel and single-resident ids from it, recording the registry's own provenance in the manifest. Running it against the archive produces the same 43 eligible homes as the transcription did, so the two agree where both had data.

A test asserts the screener reads the registry, that the panel is 22, that `hh107` and `hh121` are excluded from the single-resident set, and that the source record matches.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the cohort screener's inline transcription of the Zenodo resident table with the machine-readable resident registry, so eligibility comes from a single source of truth. The two had already drifted: the registry lists 95 single-resident homes, the transcription had 93, missing `aruba` and `navan`. Neither appears in `labeled_data.zip`, so the eligible cohort stays at 43 homes.

- The screener now loads the development panel and single-resident ids from the registry and records the registry's provenance in the manifest.
- A test asserts the screener reads the registry, that the panel is 22, and that `hh107` and `hh121` are excluded from the single-resident set.

<sup>Written for commit 4eec32a8f0b9e60417fd817bbe5fdbcf43f85658. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

