### PR TITLE
Format the external archive inventory

### DIFF
--- a/scripts/inventory_v03_external_archive.py
+++ b/scripts/inventory_v03_external_archive.py
@@ -13,9 +13,7 @@ import re
 from collections import Counter
 from pathlib import Path
 
-_TIMESTAMP = re.compile(
-    r"^\s*(\d{4}-\d{2}-\d{2})[\s,]+(\d{2}:\d{2}:\d{2}(?:\.\d+)?)"
-)
+_TIMESTAMP = re.compile(r"^\s*(\d{4}-\d{2}-\d{2})[\s,]+(\d{2}:\d{2}:\d{2}(?:\.\d+)?)")
 _MARKER = re.compile(r'([A-Za-z][A-Za-z0-9_]*)\s*=\s*"?(begin|end)"?', re.I)
 _TOKEN = re.compile(r"[A-Za-z0-9]+")
 
@@ -36,9 +34,7 @@ def _home_matches(path: Path, known_ids: set[str]) -> list[str]:
     """Return resident-registry IDs explicitly represented in a path component."""
     components = [path.stem, *path.parts[:-1]]
     normalised = {_normalise(component) for component in components if component}
-    return sorted(
-        home_id for home_id in known_ids if _normalise(home_id) in normalised
-    )
+    return sorted(home_id for home_id in known_ids if _normalise(home_id) in normalised)
 
 
 def _delimiter(line: str) -> str:

--- a/tests/test_v03_external_archive_inventory.py
+++ b/tests/test_v03_external_archive_inventory.py
@@ -36,9 +36,9 @@ def test_inventory_excludes_development_and_hashes_candidates(tmp_path: Path) ->
     assert set(homes) == {"aruba", "hh104"}
     assert homes["hh104"]["archive_member_found"] is True
     assert homes["hh104"]["files"][0]["sha256"]
-    assert homes["hh104"]["files"][0]["raw_text_audit"][
-        "annotation_marker_labels"
-    ] == {"Cook": 1}
+    assert homes["hh104"]["files"][0]["raw_text_audit"]["annotation_marker_labels"] == {
+        "Cook": 1
+    }
     assert homes["aruba"]["archive_member_found"] is False
     assert payload["model_inference_performed"] is False
     assert payload["performance_metrics_computed"] is False
@@ -47,9 +47,7 @@ def test_inventory_excludes_development_and_hashes_candidates(tmp_path: Path) ->
 def test_home_matching_requires_explicit_path_component() -> None:
     path = Path("root/not-hh104-ish/data.csv")
     assert inventory._home_matches(path, {"hh104"}) == []
-    assert inventory._home_matches(Path("root/hh104/data.csv"), {"hh104"}) == [
-        "hh104"
-    ]
+    assert inventory._home_matches(Path("root/hh104/data.csv"), {"hh104"}) == ["hh104"]
 
 
 def test_output_is_json_serialisable(tmp_path: Path) -> None:


### PR DESCRIPTION
Applies the repository-pinned Black 23.9.1 output to the two files added by #128. Formatting only; no behavior changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies the repository-pinned Black 23.9.1 formatting to the external archive inventory script and its tests. Formatting only, no behavior changes.

<sup>Written for commit a758568645476e54755eef048605fef77e0d5790. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

