### PR TITLE
Record the external cohort's composition before scoring

### DIFF
--- a/artifacts/v03/external_cohort_manifest_draft.json
+++ b/artifacts/v03/external_cohort_manifest_draft.json
@@ -31,6 +31,14 @@
     "hh129",
     "hh130"
   ],
+  "development_panel_family": "hh",
+  "eligible_by_family": {
+    "hh": 8,
+    "ihs": 2,
+    "mn": 3,
+    "rw": 5,
+    "tm": 25
+  },
   "eligible_count": 43,
   "eligible_homes": [
     {
@@ -985,7 +993,7 @@
       "unmapped_locations": []
     }
   ],
-  "note": "Eligibility read from the resident registry rather than an inline copy. Every exclusion is a contract criterion; none is a parser defect. Not frozen: freezing the cohort is a deliberate act taken before scoring.",
+  "note": "Eligibility read from the resident registry. Every exclusion is a contract criterion, not a parser defect. Not frozen.",
   "purpose": "external-validation primary test cohort",
   "schema_version": 1,
   "scored": false,

--- a/docs/EXTERNAL_COHORT_COMPOSITION.md
+++ b/docs/EXTERNAL_COHORT_COMPOSITION.md
@@ -1,0 +1,59 @@
+# External test cohort: what it is, and how a result should be read
+
+The eligible external-validation cohort is 43 single-resident CASAS homes
+outside the 22-recording development panel, selected by the contract's criteria
+and by nothing about how well they would score. This page records a property of
+that cohort which changes how its result should be interpreted, written before
+any scoring.
+
+## Composition
+
+| Family | Homes | Median labelled coverage | Median mapped states |
+| --- | --- | --- | --- |
+| `tm` | 25 | 71.5% | 6 |
+| `hh` | 8 | 85.6% | 6 |
+| `rw` | 5 | 75.7% | 6 |
+| `mn` | 3 | 82.7% | 6 |
+| `ihs` | 2 | 68.3% | 6 |
+
+## The candidate has only ever seen `hh`
+
+Every development result behind v0.3 — the emission-rate measurements, the
+recoverable-signal ceiling, the feature ablation, the circadian fit, and the
+held-out comparison that selected the candidate — came from `hh` recordings.
+
+**Only 8 of the 43 eligible test homes, 19%, are from that family.** The other
+81% come from instrumentation the candidate has never been exposed to, in homes
+whose sensor naming this project's adapter learned to read only while screening
+the cohort.
+
+That is a deliberately harder test than the development panel implies, and it is
+the right test: a method that only transfers within one research group's
+deployment convention has not transferred. But it means the result carries two
+questions at once, and they should not be conflated.
+
+## How to read each outcome
+
+**A positive result** would be strong, because it would show transfer across
+instrumentation families rather than merely across homes.
+
+**A null or negative result is ambiguous on its own.** It could mean the
+circadian prior does not transfer, or that the adapter's mapping of an
+unfamiliar vocabulary loses information, or that these families differ in ways
+the seven-state ontology does not accommodate. The primary estimand cannot
+separate those.
+
+The pre-specified secondary outcomes help but do not resolve it. A per-family
+breakdown of the paired difference is worth reporting alongside the primary
+result — not as a substitute for it, and not as a basis for excluding families
+after seeing their outcomes, which the contract forbids.
+
+## What this does not license
+
+Nothing here is a reason to narrow the cohort. Eligibility is fixed by the
+contract's criteria, and dropping a family because it scored badly would be
+exactly the post-hoc selection the one-shot design exists to prevent.
+
+This page is a statement about interpretation, written before the outcome is
+known, so that a disappointing result is read carefully rather than explained
+away afterwards.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
       - Simulation protocols: SIMULATION_PROTOCOLS.md
       - v0.3 candidate specification: V03_CANDIDATE_SPECIFICATION.md
       - v0.3 freeze verification: V03_PROFILE_FREEZE_VERIFICATION.md
+      - External cohort composition: EXTERNAL_COHORT_COMPOSITION.md
       - Adversarial review: ADVERSARIAL_REVIEW.md
       - Release readiness: RELEASE_READINESS.md
   - Modelling core:

--- a/scripts/build_external_cohort_manifest.py
+++ b/scripts/build_external_cohort_manifest.py
@@ -141,6 +141,15 @@ def main() -> None:
     screened = [screen(path, zone, panel, single_resident) for path in paths]
     eligible = [row for row in screened if row["eligible"]]
 
+    # Family composition decides how a result should be read. The candidate was
+    # developed entirely on `hh`; a cohort drawn mostly from other families is a
+    # harder test than the development panel implies, and a null result there
+    # means something different from a null result within `hh`.
+    families: dict[str, int] = {}
+    for row in eligible:
+        family = str(row["id"]).rstrip("0123456789")
+        families[family] = families.get(family, 0) + 1
+
     manifest = {
         "schema_version": 1,
         "status": "prospective-cohort-manifest",
@@ -162,6 +171,8 @@ def main() -> None:
         },
         "development_panel": sorted(panel),
         "eligible_count": len(eligible),
+        "eligible_by_family": dict(sorted(families.items())),
+        "development_panel_family": "hh",
         "eligible_homes": eligible,
         "screened": screened,
     }

--- a/scripts/inventory_v03_external_archive.py
+++ b/scripts/inventory_v03_external_archive.py
@@ -13,9 +13,7 @@ import re
 from collections import Counter
 from pathlib import Path
 
-_TIMESTAMP = re.compile(
-    r"^\s*(\d{4}-\d{2}-\d{2})[\s,]+(\d{2}:\d{2}:\d{2}(?:\.\d+)?)"
-)
+_TIMESTAMP = re.compile(r"^\s*(\d{4}-\d{2}-\d{2})[\s,]+(\d{2}:\d{2}:\d{2}(?:\.\d+)?)")
 _MARKER = re.compile(r'([A-Za-z][A-Za-z0-9_]*)\s*=\s*"?(begin|end)"?', re.I)
 _TOKEN = re.compile(r"[A-Za-z0-9]+")
 
@@ -36,9 +34,7 @@ def _home_matches(path: Path, known_ids: set[str]) -> list[str]:
     """Return resident-registry IDs explicitly represented in a path component."""
     components = [path.stem, *path.parts[:-1]]
     normalised = {_normalise(component) for component in components if component}
-    return sorted(
-        home_id for home_id in known_ids if _normalise(home_id) in normalised
-    )
+    return sorted(home_id for home_id in known_ids if _normalise(home_id) in normalised)
 
 
 def _delimiter(line: str) -> str:


### PR DESCRIPTION
The eligible cohort spans five instrumentation families, and the candidate has only ever seen one of them.

| Family | Homes |
| --- | --- |
| `tm` | 25 |
| `hh` | 8 |
| `rw` | 5 |
| `mn` | 3 |
| `ihs` | 2 |

Every development result behind v0.3 came from `hh` recordings. **Only 19% of the test cohort is from that family**; the other 81% is instrumentation the candidate has never been exposed to, whose sensor naming the adapter learned to read only while screening the cohort.

That is the right test — a method that transfers only within one deployment convention has not transferred — but it means a null result would be ambiguous between the prior failing to transfer, the mapping of an unfamiliar vocabulary losing information, and those families differing in ways the ontology does not accommodate. The primary estimand cannot separate them.

Written before scoring, so a disappointing result is read carefully rather than explained away afterwards. It explicitly does not license narrowing the cohort: dropping a family for scoring badly is the post-hoc selection the one-shot design prevents.

The manifest now also carries `eligible_by_family` machine-readably.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records the external-validation cohort's family composition before scoring, so a null result is read carefully rather than explained away afterwards.

- Only 8 of 43 eligible homes (19%) come from `hh`, the only instrumentation family behind the v0.3 development results; the rest use sensor naming the adapter learned only while screening the cohort.
- A null or negative result is ambiguous between the prior failing to transfer, vocabulary-mapping information loss, and families differing beyond the seven-state ontology, and the primary estimand cannot separate them.
- The manifest now carries `eligible_by_family` and `development_panel_family` machine-readably.
- Adds a docs page on interpreting each outcome, which explicitly does not license narrowing the cohort after the fact.

<sup>Written for commit 06ae3091f50792e083e054be5d44587e970f570a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

