### PR TITLE
Record screening provenance in the cohort manifest

### DIFF
--- a/artifacts/v03/external_cohort_manifest_draft.json
+++ b/artifacts/v03/external_cohort_manifest_draft.json
@@ -993,7 +993,7 @@
       "unmapped_locations": []
     }
   ],
-  "note": "Eligibility read from the resident registry. Every exclusion is a contract criterion, not a parser defect. Not frozen.",
+  "note": "Eligibility read from the resident registry; every exclusion is a contract criterion, not a parser defect. Records the screening revision and registry checksum so a frozen cohort traces to the code and metadata that produced it. Not frozen.",
   "purpose": "external-validation primary test cohort",
   "schema_version": 1,
   "scored": false,
@@ -2254,9 +2254,11 @@
       "unmapped_locations": []
     }
   ],
+  "screening_revision": "13722ab2e4e8b26f88f2f5cac02e3039d33d8ac7",
   "source": {
     "provider": "CASAS / Zenodo",
     "record": "15708568",
+    "registry_sha256": "d5f0c1086ba06cbf095206019a3cff2bebfd6cedf09ecd6b496d703443393066",
     "registry_source": {
       "archive": "labeled_data.zip",
       "archive_bytes": 236037656,

--- a/scripts/build_external_cohort_manifest.py
+++ b/scripts/build_external_cohort_manifest.py
@@ -4,6 +4,11 @@ The contract requires the eligible test-home identifiers and raw-file checksums
 to be frozen in a machine-readable manifest **before** primary scoring. This
 builds that manifest.
 
+The manifest records the revision of this script and the checksum of the
+registry it read, so a frozen cohort can be traced to the code and the metadata
+that produced it. The profile freeze records its fitting revision for the same
+reason; a cohort without one would be the weaker half of the pair.
+
 It is outcome-blind by construction. It reads resident-count metadata, file
 sizes, checksums and activity annotations; it never constructs a pipeline, never
 runs inference, and never computes a metric. Eligibility is decided by the
@@ -127,6 +132,11 @@ def main() -> None:
     parser.add_argument("--timezone", default="America/Los_Angeles")
     parser.add_argument("--source-record", default="15708568")
     parser.add_argument("--registry", type=Path, default=REGISTRY_PATH)
+    parser.add_argument(
+        "--screening-revision",
+        required=True,
+        help="Git revision of the screening code, recorded in the manifest",
+    )
     args = parser.parse_args()
 
     panel, single_resident, registry_source = load_registry(args.registry)
@@ -152,6 +162,7 @@ def main() -> None:
 
     manifest = {
         "schema_version": 1,
+        "screening_revision": args.screening_revision,
         "status": "prospective-cohort-manifest",
         "purpose": "external-validation primary test cohort",
         "scored": False,
@@ -160,6 +171,7 @@ def main() -> None:
             "record": args.source_record,
             "resident_counts": "artifacts/v03/casas_v1_resident_registry.json",
             "registry_source": registry_source,
+            "registry_sha256": _sha256(args.registry),
         },
         "criteria": {
             "outside_development_panel": True,
@@ -183,6 +195,7 @@ def main() -> None:
     print(
         json.dumps(
             {
+                "screening_revision": args.screening_revision,
                 "eligible": len(eligible),
                 "screened": len(screened),
                 "homes": [row["id"] for row in eligible],

--- a/tests/test_casas_hh.py
+++ b/tests/test_casas_hh.py
@@ -339,3 +339,27 @@ def test_the_cohort_screener_reads_the_resident_registry() -> None:
     assert "hh107" not in single and "hh121" not in single
     assert "hh104" in single
     assert source.get("record") == "15708568"
+
+
+def test_the_cohort_manifest_records_its_own_provenance() -> None:
+    """A frozen cohort must trace to the code and metadata that produced it.
+
+    The profile freeze records its fitting revision. A cohort manifest without
+    the equivalent would be the weaker half of the pair: the homes could not be
+    tied to the screening logic that selected them.
+    """
+    import json
+    from pathlib import Path
+
+    manifest = json.loads(
+        Path("artifacts/v03/external_cohort_manifest_draft.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert len(manifest["screening_revision"]) == 40
+    assert len(manifest["source"]["registry_sha256"]) == 64
+    assert manifest["source"]["resident_counts"].endswith(
+        "casas_v1_resident_registry.json"
+    )
+    assert manifest["scored"] is False


### PR DESCRIPTION
The profile freeze records its fitting revision. The cohort manifest recorded nothing equivalent, so a frozen cohort could not be traced to the code that selected it — the weaker half of the pair.

`--screening-revision` is now required and written into the manifest, alongside the SHA-256 of the resident registry the screener read. A frozen cohort therefore ties to both the screening logic and the metadata it depended on.

Regenerated from `13722ab`, the current merged head, rather than from the working tree it was previously built in. Same 43 homes, so the change is provenance only.

This matters once: the manifest is about to become immutable, and the script producing it changed three times today. A manifest whose provenance points at an intermediate state would be difficult to defend later.

A test asserts the manifest carries a 40-character revision, a 64-character registry checksum, a registry path, and `scored: false`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cohort manifests previously recorded no provenance for the screening code or resident registry; they now require a screening revision and record the registry SHA-256, so frozen cohorts can be traced to both inputs. The regenerated draft still contains the same 43 homes and remains unscored.

**Migration**

- Calls to `build_external_cohort_manifest.py` must now pass `--screening-revision`.
- Tests verify the revision, checksum, registry path, and `scored: false` fields.

<sup>Written for commit dd51dc37668b950745adfc702b5b0d86d324d4d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

