### PR TITLE
Abstention cannot be repaired by raising its threshold

### DIFF
--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -287,7 +287,7 @@ this biases inference toward inactivity — measured at kitchen recall 0.705 →
 | --- | --- |
 | Declared defaults do not transfer: 22 real homes, median balanced accuracy 0.420 against 0.816 | **High** |
 | `home_inactive` recall 0.16 on real homes; declared event rates 7-14x below measured | **High** |
-| Abstention does not fire when wrong on real data (median 2.5%, max 3.9%) | **High** |
+| Abstention does not fire when wrong, and confidence inverts above 0.95 so no threshold repairs it | **High** |
 | Simulator reports 0.816, above the 0.607 recoverable from real instrumentation | **High** |
 | Pipeline recovers two thirds of what real sensors support (0.420 of 0.607) | **High** |
 | Small-sample pilots reported as though they were studies | High, addressed |

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -26,6 +26,18 @@ measured rates doubles to triples `home_inactive` recall but costs sleeping
 recall and calibration, so it points the work somewhere specific without
 resolving it.
 
+**Abstention cannot be repaired by raising its threshold.** It fired on 2.2% of
+steps while the model was wrong more often than right, and the obvious fix —
+thresholds tuned for a simulator where the model is right 82% of the time — does
+not work. Over 60,948 scored steps, stated confidence separates right from wrong
+by only 0.073, and the relationship inverts where it matters: the 0.95-1.00
+band, covering 39% of all steps, is *less* accurate (0.561) than the 0.85-0.95
+band (0.653). Raising the threshold discards the pipeline's best band and keeps
+its saturated one. The likely cause is that during quiet periods the belief
+approaches certainty because no evidence arrived, not because the evidence was
+strong. This is a safety limitation, not a tuning parameter, and the v0.3
+candidate does not touch it.
+
 An earlier revision of this page reported `away` recall of 0.00 and treated it
 as a finding. **That was wrong.** `Leave_Home` annotates twelve seconds of
 crossing the threshold, not the hours spent out, so the truth series labelled

--- a/docs/real_data.md
+++ b/docs/real_data.md
@@ -542,6 +542,51 @@ what the output feeds.
 Stacking them is the one thing to avoid, and it is exactly what a reader would
 do by default given three separate features each documented as an improvement.
 
+### Why abstention does not fire, and why raising the threshold will not fix it
+
+The pipeline abstained on 2.2% of steps while being wrong more often than right.
+The obvious reading is that the thresholds were set for the simulator, where the
+model is right about 82% of the time, and are simply too low for real data. That
+reading is wrong.
+
+Over 60,948 scored steps from five homes, stated confidence separates correct
+from incorrect answers by only **+0.073**: mean 0.832 when right against 0.758
+when wrong. Worse, the relationship is not monotonic where it matters most.
+
+| Stated confidence | Steps | Accuracy |
+| --- | --- | --- |
+| 0.00 – 0.30 | 360 | 0.475 |
+| 0.30 – 0.50 | 5,459 | 0.314 |
+| 0.50 – 0.70 | 15,535 | 0.384 |
+| 0.70 – 0.85 | 7,813 | 0.506 |
+| 0.85 – 0.95 | 8,127 | **0.653** |
+| **0.95 – 1.00** | **23,654** | **0.561** |
+
+**The most confident band is less accurate than the band below it**, and it is
+the largest, covering 39% of all scored steps. Raising the abstention threshold
+therefore cannot work: it discards the 0.85–0.95 band, which is the pipeline's
+best, while keeping the saturated one.
+
+The thresholds bear this out. Abstaining below 0.90 keeps 47% of steps at
+accuracy 0.579 against a 0.498 baseline; abstaining below 0.95 keeps 39% and
+accuracy *falls* to 0.561.
+
+The likely mechanism is saturation rather than evidence. During a long quiet
+period the chain's stickiness carries the belief toward one state and nothing
+arrives to contradict it, so the posterior approaches certainty because no
+evidence has been seen, not because the evidence is strong. Those steps are
+confident by construction, and the ontology's dwell times — 3 to 9 times longer
+than real state durations — make the effect worse.
+
+**This is a safety finding, not a tuning one.** The project presents abstention
+as the mechanism that makes the rest defensible: a model that does not know
+should say so. On real recordings the quantity it uses to decide that is only
+weakly related to whether it is right, and inverts exactly where the model is
+most assertive. No threshold setting repairs a signal shaped like this.
+
+It is also untouched by the v0.3 candidate, which changes the transition prior
+and leaves the abstention path alone.
+
 ### Explanations tested and rejected
 
 - **An incomplete location map.** `DiningRoom` was unmapped in 14 homes.


### PR DESCRIPTION
I recorded earlier that abstention fired on 2.2% of steps while the model was wrong more often than right, and left it there. This asks why, and the answer is worse than a mis-set threshold.

Over 60,948 scored steps from five homes, stated confidence separates correct from incorrect answers by only **+0.073** — 0.832 when right, 0.758 when wrong. And the relationship inverts where it matters most:

| Stated confidence | Steps | Accuracy |
| --- | --- | --- |
| 0.50 – 0.70 | 15,535 | 0.384 |
| 0.70 – 0.85 | 7,813 | 0.506 |
| 0.85 – 0.95 | 8,127 | **0.653** |
| **0.95 – 1.00** | **23,654** | **0.561** |

The most confident band is less accurate than the band below it, and it is the largest at 39% of steps. Raising the threshold therefore discards the pipeline's best band while keeping its saturated one: abstaining below 0.90 gives accuracy 0.579, below 0.95 gives 0.561.

The likely mechanism is saturation rather than evidence — during a quiet period the chain's stickiness carries the belief toward certainty because nothing arrives to contradict it, and dwell times 3 to 9 times longer than real durations make that worse.

This is a safety finding rather than a tuning one. Abstention is presented throughout as what makes the rest defensible, and on real recordings the quantity deciding it is only weakly related to correctness and inverts where the model is most assertive. The v0.3 candidate changes the transition prior and leaves this path untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents why abstention cannot be repaired by raising its threshold: over 60,948 real steps, stated confidence separates right from wrong by only +0.073 and inverts above 0.95, so raising the threshold discards the best band (0.85–0.95, accuracy 0.653) while keeping the saturated one (0.561). This is a safety limitation, not a tuning parameter, and the v0.3 candidate does not touch it.

**Docs**
- Adds the finding and severity line to `docs/RELEASE_READINESS.md`.
- Adds a limitation entry to `docs/limitations.md`.
- Details the confidence-band analysis and mechanism in `docs/real_data.md`.

<sup>Written for commit a39e7d2cc73cc637787640e05f9105f65027027a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

