### PR TITLE
Stop scoring the day-closing estimate twice

### DIFF
--- a/scripts/score_v03_external.py
+++ b/scripts/score_v03_external.py
@@ -1,0 +1,323 @@
+"""Score the frozen v0.3 candidate against v0.2 on the frozen external cohort.
+
+This is the one-shot primary external validation. Running it against the frozen
+cohort is not repeatable under the validation contract: whatever it reports
+stands, and no parameter, mapping, threshold or cohort membership may be changed
+in response and rescored as the same confirmatory evidence.
+
+The script therefore refuses to run unless every input matches what was frozen.
+It verifies the profile digest, the cohort manifest's own recorded state, and the
+SHA-256 of every recording it reads. A silent mismatch would produce a number
+that looks like the pre-registered result and is not.
+
+Use ``--cohort development`` to exercise the runner on already-inspected
+development homes. That path is for checking the machinery works and reports
+nothing about the primary cohort.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import statistics
+from dataclasses import dataclass
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import numpy as np
+
+from sensor_modeling.datasets import read_casas_hh
+from sensor_modeling.datasets.casas import truth_series
+from sensor_modeling.evaluation.metrics import StateMetrics, state_metrics
+from sensor_modeling.online import BehaviouralSensingPipeline, PipelineConfig
+from sensor_modeling.states import BehaviouralState, StateOntology
+
+COHORT_PATH = Path("artifacts/v03/external_cohort_manifest.json")
+PROFILE_PATH = Path("artifacts/v03/v03_circadian_profile.json")
+
+#: A state is reported individually only if it appears in at least this many
+#: homes, per the contract's secondary-outcome definition.
+MINIMUM_HOMES_FOR_STATE = 3
+
+#: Resampling draws for the paired bootstrap over homes.
+BOOTSTRAP_DRAWS = 10_000
+
+
+@dataclass(frozen=True)
+class HomeResult:
+    """Both versions scored on one home, and the paired contrast."""
+
+    home: str
+    reference: StateMetrics
+    candidate: StateMetrics
+    scored_points: int
+    labelled_fraction: float
+
+    @property
+    def difference(self) -> float:
+        """``D_h``: candidate balanced accuracy minus reference."""
+        return self.candidate.balanced_accuracy - self.reference.balanced_accuracy
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "home": self.home,
+            "scored_points": self.scored_points,
+            "labelled_fraction": self.labelled_fraction,
+            "balanced_accuracy_v02": self.reference.balanced_accuracy,
+            "balanced_accuracy_v03": self.candidate.balanced_accuracy,
+            "difference": self.difference,
+            "v02": self.reference.to_dict(),
+            "v03": self.candidate.to_dict(),
+        }
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_profile(path: Path) -> dict[BehaviouralState, tuple[float, ...]]:
+    """Load the frozen circadian profile, checking its recorded digest."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("status") != "frozen-development-fit":
+        raise SystemExit(f"profile at {path} is not a frozen development fit")
+    if payload.get("test_outcomes_inspected") is not False:
+        raise SystemExit("profile claims test outcomes were inspected; refusing")
+    return {
+        BehaviouralState(name): tuple(values)
+        for name, values in payload["fit"]["profile"].items()
+    }
+
+
+def load_cohort(path: Path) -> list[dict[str, Any]]:
+    """Load the frozen cohort, refusing anything not frozen or already scored."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("status") != "frozen-primary-external-cohort":
+        raise SystemExit(f"cohort at {path} is not frozen")
+    if payload.get("scored") is not False:
+        raise SystemExit(
+            "cohort is already marked scored; the primary validation is one-shot "
+            "and must not be repeated"
+        )
+    homes = payload["eligible_homes"]
+    if not homes:
+        raise SystemExit("frozen cohort is empty")
+    return list(homes)
+
+
+def resolve(root: Path, filename: str) -> Path:
+    """Find one recording in the archive, refusing an ambiguous match."""
+    matches = sorted(p for p in root.rglob(filename) if p.is_file())
+    if len(matches) != 1:
+        raise SystemExit(
+            f"expected exactly one archive member named {filename}, found "
+            f"{len(matches)}"
+        )
+    return matches[0]
+
+
+def score_home(
+    path: Path,
+    zone: ZoneInfo,
+    step: timedelta,
+    profile: dict[BehaviouralState, tuple[float, ...]],
+) -> HomeResult | None:
+    """Score both versions on one recording, or return ``None`` if unscoreable."""
+    recording = read_casas_hh(path, timezone=zone)
+    if not recording.observations:
+        return None
+
+    outcomes: list[StateMetrics] = []
+    moments: list[Any] = []
+    for ontology in (StateOntology(), StateOntology(circadian=profile)):
+        pipeline = BehaviouralSensingPipeline(
+            recording.registry,
+            ontology=ontology,
+            config=PipelineConfig(tz=zone, step=step),
+        )
+        steps = pipeline.run(recording.observations)
+        steps.extend(pipeline.close(recording.observations[-1].timestamp))
+        moments = [s.at for s in steps]
+        truth = truth_series(recording.activities, moments)
+        outcomes.append(state_metrics(truth, [s.state for s in steps]))
+
+    scored = sum(
+        1 for label in truth_series(recording.activities, moments) if label is not None
+    )
+    if scored == 0:
+        return None
+
+    return HomeResult(
+        home=path.stem,
+        reference=outcomes[0],
+        candidate=outcomes[1],
+        scored_points=scored,
+        labelled_fraction=recording.labelled_fraction,
+    )
+
+
+def paired_bootstrap(
+    differences: list[float], *, draws: int, seed: int
+) -> tuple[float, float]:
+    """Two-sided 95% interval on the median, resampling homes not time points."""
+    rng = np.random.default_rng(seed)
+    values = np.asarray(differences, dtype=float)
+    sample = rng.choice(values, size=(draws, values.size), replace=True)
+    medians = np.median(sample, axis=1)
+    return float(np.quantile(medians, 0.025)), float(np.quantile(medians, 0.975))
+
+
+def summarise(results: list[HomeResult], *, seed: int) -> dict[str, Any]:
+    """Build the primary and secondary outcomes the contract specifies."""
+    differences = [r.difference for r in results]
+    median = statistics.median(differences)
+    low, high = paired_bootstrap(differences, draws=BOOTSTRAP_DRAWS, seed=seed)
+
+    # State-specific recall only where the state appears in enough homes.
+    per_state: dict[str, dict[str, list[float]]] = {}
+    for result in results:
+        for version, metrics in (("v02", result.reference), ("v03", result.candidate)):
+            for state, recall in metrics.per_class_recall.items():
+                per_state.setdefault(state, {}).setdefault(version, []).append(recall)
+    states = {
+        state: {
+            version: statistics.median(values) for version, values in versions.items()
+        }
+        for state, versions in per_state.items()
+        if len(versions.get("v02", [])) >= MINIMUM_HOMES_FOR_STATE
+    }
+
+    def median_of(attribute: str, version: str) -> float:
+        source = "reference" if version == "v02" else "candidate"
+        return statistics.median(
+            getattr(getattr(r, source), attribute) for r in results
+        )
+
+    return {
+        "primary": {
+            "estimand": "median paired difference in household balanced accuracy",
+            "median_difference": median,
+            "ci_low": low,
+            "ci_high": high,
+            "homes": len(results),
+            "improved": sum(1 for d in differences if d > 0),
+            "unchanged": sum(1 for d in differences if d == 0),
+            "worsened": sum(1 for d in differences if d < 0),
+            "bootstrap_draws": BOOTSTRAP_DRAWS,
+            "resampling_unit": "home",
+        },
+        "secondary": {
+            version: {
+                "balanced_accuracy": median_of("balanced_accuracy", version),
+                "calibration_error": median_of("calibration_error", version),
+                "log_loss": median_of("log_loss", version),
+                "brier": median_of("brier", version),
+                "abstention_rate": median_of("abstention_rate", version),
+            }
+            for version in ("v02", "v03")
+        },
+        "labelled_coverage_median": statistics.median(
+            r.labelled_fraction for r in results
+        ),
+        "scored_points_total": sum(r.scored_points for r in results),
+        "state_recall_median": states,
+        "homes": [r.to_dict() for r in results],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("archive_root", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--cohort", choices=("primary", "development"), required=True)
+    parser.add_argument("--timezone", default="America/Los_Angeles")
+    parser.add_argument("--step-minutes", type=int, default=5)
+    parser.add_argument("--bootstrap-seed", type=int, default=0)
+    parser.add_argument(
+        "--i-understand-this-is-one-shot",
+        action="store_true",
+        help="Required for --cohort primary. The result stands whatever it says.",
+    )
+    args = parser.parse_args()
+
+    if args.cohort == "primary" and not args.i_understand_this_is_one_shot:
+        raise SystemExit(
+            "scoring the primary cohort is one-shot and unrepeatable; pass "
+            "--i-understand-this-is-one-shot to proceed"
+        )
+
+    zone = ZoneInfo(args.timezone)
+    step = timedelta(minutes=args.step_minutes)
+    profile = load_profile(PROFILE_PATH)
+
+    manifest = json.loads(COHORT_PATH.read_text(encoding="utf-8"))
+    if args.cohort == "primary":
+        entries = load_cohort(COHORT_PATH)
+    else:
+        panel = manifest["development_panel"]
+        entries = [
+            {"id": home, "filename": f"{home}.csv", "sha256": None} for home in panel
+        ]
+
+    results: list[HomeResult] = []
+    skipped: list[dict[str, str]] = []
+    for entry in entries:
+        path = resolve(args.archive_root, str(entry["filename"]))
+        expected = entry.get("sha256")
+        if expected is not None:
+            actual = _sha256(path)
+            if actual != expected:
+                raise SystemExit(
+                    f"{entry['id']}: archive digest {actual} does not match the "
+                    f"frozen {expected}; the cohort and the data disagree"
+                )
+        outcome = score_home(path, zone, step, profile)
+        if outcome is None:
+            skipped.append({"id": str(entry["id"]), "reason": "no scoreable points"})
+            continue
+        results.append(outcome)
+        print(
+            f"{outcome.home:10} v0.2 {outcome.reference.balanced_accuracy:.3f}  "
+            f"v0.3 {outcome.candidate.balanced_accuracy:.3f}  "
+            f"D {outcome.difference:+.3f}",
+            flush=True,
+        )
+
+    if not results:
+        raise SystemExit("no home produced a scoreable result")
+
+    payload = {
+        "schema_version": 1,
+        "cohort": args.cohort,
+        "profile_sha256": json.loads(PROFILE_PATH.read_text(encoding="utf-8"))[
+            "profile_sha256"
+        ],
+        "step_minutes": args.step_minutes,
+        "skipped": skipped,
+        **summarise(results, seed=args.bootstrap_seed),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    primary = payload["primary"]
+    print()
+    print(f"median D_h        {primary['median_difference']:+.4f}")
+    print(f"95% CI            [{primary['ci_low']:+.4f}, {primary['ci_high']:+.4f}]")
+    print(
+        f"homes             {primary['homes']}  "
+        f"({primary['improved']} improved, {primary['worsened']} worsened)"
+    )
+    print(f"median coverage   {payload['labelled_coverage_median']:.1%}")
+    print(f"written to        {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/score_v03_external.py
+++ b/scripts/score_v03_external.py
@@ -22,7 +22,7 @@ import hashlib
 import json
 import statistics
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -37,6 +37,22 @@ from sensor_modeling.states import BehaviouralState, StateOntology
 
 COHORT_PATH = Path("artifacts/v03/external_cohort_manifest.json")
 PROFILE_PATH = Path("artifacts/v03/v03_circadian_profile.json")
+DECLARATION_PATH = Path("artifacts/v03/external_cohort_freeze_declaration.json")
+
+#: Marker written after a successful primary run. Its existence is what makes
+#: the validation one-shot in practice rather than only in prose.
+CONSUMED_PATH = Path("artifacts/v03/external_primary_scored.json")
+
+#: Evaluation grid for the primary run.
+#:
+#: Neither the candidate specification nor the validation contract fixes a step
+#: size or timezone, which is a gap in the pre-registration. They are pinned
+#: here to the values every development result used, and overriding them is
+#: refused on the primary path: a different grid changes the circadian
+#: alignment and the number of scored points, so it would not be the
+#: pre-registered comparison.
+FROZEN_TIMEZONE = "America/Los_Angeles"
+FROZEN_STEP_MINUTES = 5
 
 #: A state is reported individually only if it appears in at least this many
 #: homes, per the contract's secondary-outcome definition.
@@ -82,21 +98,60 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def _canonical_fit_sha256(fit: dict[str, Any]) -> str:
+    """Digest of the fit block, matching the freeze validator byte for byte."""
+    payload = json.dumps(
+        fit, sort_keys=True, separators=(",", ":"), allow_nan=False
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
 def load_profile(path: Path) -> dict[BehaviouralState, tuple[float, ...]]:
-    """Load the frozen circadian profile, checking its recorded digest."""
+    """Load the frozen circadian profile, recomputing its digest.
+
+    Reading ``profile_sha256`` and trusting it would accept an edited profile
+    carrying the old hash, which is precisely the substitution the digest exists
+    to prevent. The digest is recomputed from the fit block and compared.
+    """
     payload = json.loads(path.read_text(encoding="utf-8"))
     if payload.get("status") != "frozen-development-fit":
         raise SystemExit(f"profile at {path} is not a frozen development fit")
     if payload.get("test_outcomes_inspected") is not False:
         raise SystemExit("profile claims test outcomes were inspected; refusing")
+
+    recorded = payload.get("profile_sha256")
+    actual = _canonical_fit_sha256(payload["fit"])
+    if recorded != actual:
+        raise SystemExit(
+            f"profile digest mismatch: recorded {recorded}, recomputed {actual}; "
+            "the profile has changed since it was frozen"
+        )
     return {
         BehaviouralState(name): tuple(values)
         for name, values in payload["fit"]["profile"].items()
     }
 
 
-def load_cohort(path: Path) -> list[dict[str, Any]]:
-    """Load the frozen cohort, refusing anything not frozen or already scored."""
+def load_cohort(path: Path, declaration: Path) -> list[dict[str, Any]]:
+    """Load the frozen cohort, checking it against its freeze declaration.
+
+    Trusting the manifest's own membership and hashes would let an edited
+    manifest be scored as frozen. The declaration records the manifest digest
+    separately, so the manifest is verified against it before any home is read.
+    """
+    if not declaration.exists():
+        raise SystemExit(f"freeze declaration not found at {declaration}")
+    freeze = json.loads(declaration.read_text(encoding="utf-8"))
+    expected = freeze.get("manifest_sha256")
+    actual = _sha256(path)
+    if expected != actual:
+        raise SystemExit(
+            f"cohort manifest digest mismatch: declaration records {expected}, "
+            f"file is {actual}; the frozen cohort has changed"
+        )
+    if freeze.get("scored") is not False:
+        raise SystemExit("freeze declaration already records the cohort as scored")
+
     payload = json.loads(path.read_text(encoding="utf-8"))
     if payload.get("status") != "frozen-primary-external-cohort":
         raise SystemExit(f"cohort at {path} is not frozen")
@@ -141,17 +196,21 @@ def score_home(
             ontology=ontology,
             config=PipelineConfig(tz=zone, step=step),
         )
+        # close() re-emits the final estimate as a reporting step carrying the
+        # day summary. Extending with it would score that one point twice, so
+        # it is flushed for its side effects and discarded here.
         steps = pipeline.run(recording.observations)
-        steps.extend(pipeline.close(recording.observations[-1].timestamp))
+        pipeline.close(recording.observations[-1].timestamp)
         moments = [s.at for s in steps]
         truth = truth_series(recording.activities, moments)
-        outcomes.append(state_metrics(truth, [s.state for s in steps]))
 
-    scored = sum(
-        1 for label in truth_series(recording.activities, moments) if label is not None
-    )
-    if scored == 0:
-        return None
+        # Computed before scoring: state_metrics raises when nothing is
+        # labelled, so a later guard would never be reached and an unscoreable
+        # home would abort the whole run instead of being skipped.
+        scored = sum(1 for label in truth if label is not None)
+        if scored == 0:
+            return None
+        outcomes.append(state_metrics(truth, [s.state for s in steps]))
 
     return HomeResult(
         home=path.stem,
@@ -246,11 +305,24 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    if args.cohort == "primary" and not args.i_understand_this_is_one_shot:
-        raise SystemExit(
-            "scoring the primary cohort is one-shot and unrepeatable; pass "
-            "--i-understand-this-is-one-shot to proceed"
-        )
+    if args.cohort == "primary":
+        if not args.i_understand_this_is_one_shot:
+            raise SystemExit(
+                "scoring the primary cohort is one-shot and unrepeatable; pass "
+                "--i-understand-this-is-one-shot to proceed"
+            )
+        if CONSUMED_PATH.exists():
+            raise SystemExit(
+                f"the primary cohort has already been scored; see {CONSUMED_PATH}. "
+                "Rescoring it would not be the same confirmatory validation."
+            )
+        if args.timezone != FROZEN_TIMEZONE or args.step_minutes != FROZEN_STEP_MINUTES:
+            raise SystemExit(
+                "the primary run uses the frozen evaluation grid "
+                f"({FROZEN_TIMEZONE}, {FROZEN_STEP_MINUTES} minutes); a different "
+                "grid changes the circadian alignment and the scored points, so "
+                "it would not be the pre-registered comparison"
+            )
 
     zone = ZoneInfo(args.timezone)
     step = timedelta(minutes=args.step_minutes)
@@ -258,7 +330,7 @@ def main() -> None:
 
     manifest = json.loads(COHORT_PATH.read_text(encoding="utf-8"))
     if args.cohort == "primary":
-        entries = load_cohort(COHORT_PATH)
+        entries = load_cohort(COHORT_PATH, DECLARATION_PATH)
     else:
         panel = manifest["development_panel"]
         entries = [
@@ -306,6 +378,27 @@ def main() -> None:
     args.output.write_text(
         json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )
+
+    if args.cohort == "primary":
+        # Written after the result exists, so a crash mid-run does not burn the
+        # one shot, and before the summary is printed, so the marker cannot be
+        # skipped by someone interrupting at the last moment.
+        CONSUMED_PATH.write_text(
+            json.dumps(
+                {
+                    "status": "primary-external-cohort-scored",
+                    "scored_at": datetime.now(timezone.utc).isoformat(),
+                    "result_file": str(args.output),
+                    "result_sha256": _sha256(args.output),
+                    "profile_sha256": payload["profile_sha256"],
+                    "homes": payload["primary"]["homes"],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
 
     primary = payload["primary"]
     print()

--- a/sensor_modeling/datasets/evaluate.py
+++ b/sensor_modeling/datasets/evaluate.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from ..evaluation.metrics import StateMetrics, state_metrics
 from ..online import BehaviouralSensingPipeline, PipelineConfig
+from ..online.pipeline import scoring_steps
 from .casas import CasasRecording, truth_series
 
 logger = logging.getLogger(__name__)
@@ -107,6 +108,9 @@ def evaluate_recording(
     pipeline = BehaviouralSensingPipeline(recording.registry, config=settings)
     steps = pipeline.run(recording.observations)
     steps.extend(pipeline.close(recording.observations[-1].timestamp))
+    # close() re-emits the final estimate as a reporting step; scoring it as
+    # well would weight that one point twice.
+    steps = scoring_steps(steps)
     if not steps:
         raise ValueError("pipeline produced no steps for this recording")
 

--- a/sensor_modeling/evaluation/attribution.py
+++ b/sensor_modeling/evaluation/attribution.py
@@ -25,7 +25,11 @@ from typing import Any
 
 import numpy as np
 
-from ..online.pipeline import BehaviouralSensingPipeline, PipelineConfig
+from ..online.pipeline import (
+    BehaviouralSensingPipeline,
+    PipelineConfig,
+    scoring_steps,
+)
 from ..simulation.faults import DegradationConfig, degrade, dropout, not_worn
 from ..simulation.household import HouseholdConfig, simulate
 from .metrics import BinaryMetrics, StateMetrics, binary_metrics, state_metrics
@@ -204,6 +208,9 @@ def _run_arm(
     )
     steps = pipeline.run(observations)
     steps.extend(pipeline.close(result.end))
+    # close() re-emits the final estimate; scoring it twice would weight that
+    # point double in every per-scenario metric.
+    steps = scoring_steps(steps)
     if not steps:
         raise ValueError("scenario produced no pipeline steps")
 

--- a/sensor_modeling/models/change_point_detection/deep.py
+++ b/sensor_modeling/models/change_point_detection/deep.py
@@ -5,6 +5,7 @@ as a lightweight stand-in for more sophisticated deep architectures.
 It trains on sliding windows of the input sequence and classifies whether
 the next time step contains a change point.
 """
+
 from __future__ import annotations
 
 from collections.abc import Sequence

--- a/sensor_modeling/models/nhpp_pelt/bspline.py
+++ b/sensor_modeling/models/nhpp_pelt/bspline.py
@@ -75,9 +75,11 @@ def _basis_at_scalar(t: float, degree: int, knots: Array1D) -> Array1D:
             right = (
                 0.0
                 if right_den <= 0
-                else (knots[i + k + 1] - t) / right_den * N[k - 1, i + 1]
-                if i + 1 < n_basis
-                else 0.0
+                else (
+                    (knots[i + k + 1] - t) / right_den * N[k - 1, i + 1]
+                    if i + 1 < n_basis
+                    else 0.0
+                )
             )
             N[k, i] = left + right
 

--- a/sensor_modeling/online/pipeline.py
+++ b/sensor_modeling/online/pipeline.py
@@ -470,6 +470,25 @@ def local_midnight(day: date, zone: tzinfo | None) -> datetime:
     return naive.replace(tzinfo=zone) if zone is not None else naive
 
 
+def scoring_steps(steps: "Sequence[PipelineStep]") -> "list[PipelineStep]":
+    """Return steps with the day-closing duplicate removed.
+
+    :meth:`BehaviouralSensingPipeline.close` re-emits the final estimate as a
+    reporting step so that the last day's summary, changes and alerts are not
+    lost. That step carries the *same* estimate object as the preceding one, so
+    code that extends its step list with it and then scores the result counts
+    that estimate twice.
+
+    Alert collection wants every step. Scoring wants each estimate once. This
+    returns the latter, dropping a trailing step whose estimate is the one
+    already present.
+    """
+    ordered = list(steps)
+    if len(ordered) >= 2 and ordered[-1].state is ordered[-2].state:
+        return ordered[:-1]
+    return ordered
+
+
 def collect_alerts(steps: Iterable[PipelineStep]) -> list[Alert]:
     """Return every alert raised across a run, in order."""
     return [alert for step in steps for alert in step.alerts]

--- a/sensor_modeling/utils/missing.py
+++ b/sensor_modeling/utils/missing.py
@@ -168,9 +168,9 @@ def handle_missing_data(
 
     return MissingDataResult(
         data=data,
-        original_missing_mask=original_missing
-        if strategy != "drop"
-        else original_missing.loc[data.index],
+        original_missing_mask=(
+            original_missing if strategy != "drop" else original_missing.loc[data.index]
+        ),
         imputed_mask=imputed_mask,
         remaining_missing_mask=remaining_missing,
         long_gap_mask=long_gap,

--- a/tests/test_smoothing.py
+++ b/tests/test_smoothing.py
@@ -32,7 +32,7 @@ def beliefs(*peaks: int, confidence: float = 0.8) -> np.ndarray:
     return np.vstack(rows)
 
 
-def estimates(array: np.ndarray) -> list[StateEstimate]:
+def estimates_from(array: np.ndarray) -> list[StateEstimate]:
     start = datetime(2011, 6, 15, 12, 0, tzinfo=UTC)
     return [
         StateEstimate(
@@ -97,7 +97,7 @@ class TestBeliefs:
 class TestEstimates:
     def test_evidence_is_left_untouched(self) -> None:
         """It records what the sensors argued at the time, not afterwards."""
-        original = estimates(beliefs(0, 3, 0))
+        original = estimates_from(beliefs(0, 3, 0))
         smoothed = smooth_estimates(original, lag=1)
 
         for before, after in zip(original, smoothed):
@@ -105,23 +105,84 @@ class TestEstimates:
             assert after.at == before.at
 
     def test_beliefs_are_revised(self) -> None:
-        original = estimates(beliefs(0, 3, 0))
+        original = estimates_from(beliefs(0, 3, 0))
         smoothed = smooth_estimates(original, lag=2)
 
         assert not np.allclose(smoothed[1].belief, original[1].belief)
 
     def test_zero_lag_returns_the_input(self) -> None:
-        original = estimates(beliefs(0, 3, 0))
+        original = estimates_from(beliefs(0, 3, 0))
         assert smooth_estimates(original, lag=0) == original
 
     def test_out_of_order_estimates_are_refused(self) -> None:
         """The backward recursion would otherwise mix unrelated moments."""
-        original = estimates(beliefs(0, 3, 0))
+        original = estimates_from(beliefs(0, 3, 0))
         shuffled = [original[2], original[0], original[1]]
 
         with pytest.raises(ValueError, match="ascending time order"):
             smooth_estimates(shuffled, lag=1)
 
     def test_a_single_estimate_is_returned_unchanged(self) -> None:
-        original = estimates(beliefs(0))
+        original = estimates_from(beliefs(0))
         assert smooth_estimates(original, lag=3) == original
+
+
+class TestScoringSteps:
+    """`close()` re-emits the final estimate, which scoring must not count twice.
+
+    The pipeline's closing step exists so the last day's summary, changes and
+    alerts are not lost. It carries the same estimate object as the step before
+    it, so code that extends its list and then scores the result weights that
+    one estimate double. Alert collection wants every step; scoring wants each
+    estimate once.
+    """
+
+    @staticmethod
+    def _steps(count: int, duplicate_last: bool):
+        from sensor_modeling.online.pipeline import PipelineStep
+
+        array = beliefs(*([0] * count))
+        estimates = estimates_from(array)
+        steps = [
+            PipelineStep(
+                at=e.at, state=e, context=None, health=None, alerts=(), changes=()
+            )
+            for e in estimates
+        ]
+        if duplicate_last:
+            last = steps[-1]
+            steps.append(
+                PipelineStep(
+                    at=last.at,
+                    state=last.state,
+                    context=None,
+                    health=None,
+                    alerts=(),
+                    changes=(),
+                )
+            )
+        return steps
+
+    def test_a_trailing_duplicate_estimate_is_dropped(self) -> None:
+        from sensor_modeling.online.pipeline import scoring_steps
+
+        steps = self._steps(4, duplicate_last=True)
+        assert len(steps) == 5
+        assert len(scoring_steps(steps)) == 4
+
+    def test_distinct_estimates_are_kept(self) -> None:
+        from sensor_modeling.online.pipeline import scoring_steps
+
+        steps = self._steps(4, duplicate_last=False)
+        assert len(scoring_steps(steps)) == 4
+
+    def test_a_single_step_is_unchanged(self) -> None:
+        from sensor_modeling.online.pipeline import scoring_steps
+
+        steps = self._steps(1, duplicate_last=False)
+        assert len(scoring_steps(steps)) == 1
+
+    def test_an_empty_sequence_is_unchanged(self) -> None:
+        from sensor_modeling.online.pipeline import scoring_steps
+
+        assert scoring_steps([]) == []


### PR DESCRIPTION
Found by the reviewer on #138, and it is not confined to that script.

`BehaviouralSensingPipeline.close()` re-emits the final estimate as a reporting step so the last day's summary, changes and alerts are not lost. It carries the *same* estimate object as the preceding step. Every call site doing `steps.extend(pipeline.close(...))` and then scoring therefore weights that estimate twice.

Measured on hh103: `run()` returns 16,561 steps, `close()` returns 1 with an identical timestamp and the same state object — **0.006% of scored points**. Immaterial to the reported numbers, and wrong regardless.

Adds `scoring_steps()`, which drops a trailing step whose estimate is the one already present, and wires it into the two scoring paths: `datasets/evaluate.py` and `evaluation/attribution.py`. `evaluation/detection.py` is deliberately left alone — it collects alerts rather than scoring states, and needs the closing step to see the final day's alerts.

Re-running the external scoring runner over the 22 development homes before and after gives identical output — median D_h +0.0084, CI [+0.0068, +0.0120], 21 of 22 improved — which is the expected result at this magnitude and confirms the change is behaviour-preserving where it should be.

Four tests cover the helper, including that distinct estimates are kept and an empty sequence is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents state-scoring code from counting the day-closing estimate twice. `close()` still emits that estimate for final-day summaries, changes, and alerts, while scoring removes only the trailing duplicate; alert collection is unchanged.

**New Features**

- Adds a one-shot external scoring runner for comparing v0.2 and v0.3 across frozen cohorts.
- Validates frozen profiles, cohort manifests, and recording hashes, pins the primary evaluation grid, and records when the run has been consumed.
- Tests duplicate, distinct, single-step, and empty sequences for the scoring helper.

<sup>Written for commit 1e635c3b28cb2c2b8b88f5709fe3b8cbfef59040. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

