### PR TITLE
Record the evaluation grid before scoring

### DIFF
--- a/docs/V03_CANDIDATE_SPECIFICATION.md
+++ b/docs/V03_CANDIDATE_SPECIFICATION.md
@@ -48,6 +48,30 @@ For the primary external comparison, v0.2 and v0.3 must use the same:
 
 Only the circadian profile differs.
 
+## Evaluation grid
+
+The list above requires v0.2 and v0.3 to share an evaluation grid, which makes
+the paired contrast internally valid whatever the grid is. It does not record
+what the grid *is*, so the absolute per-home figures were not reproducible from
+the specification alone. Recorded here before any primary scoring:
+
+| | Value |
+| --- | --- |
+| Inference step | 5 minutes |
+| Local timezone | `America/Los_Angeles` |
+
+These are the values every development result used, including the held-out
+comparison that selected the candidate. They are not a new choice; they are the
+existing one written down.
+
+The step size and timezone both matter beyond bookkeeping. The step sets how
+many points each home contributes and how much evidence each carries, and the
+timezone determines which local hour the circadian profile is indexed by — a
+displaced zone would silently misalign the very mechanism under test.
+
+`scripts/score_v03_external.py` refuses any other grid on the primary path, so
+the recorded values are enforced rather than merely documented.
+
 ## Development fitting of the final profile
 
 The previously analysed development panel contains 22 `hh` recordings. CASAS metadata identify `hh107` and `hh121` as two-resident homes. They remain permanently development-only because their outcomes were already inspected, but they are not eligible to estimate the final single-resident circadian profile.


### PR DESCRIPTION
The specification requires v0.2 and v0.3 to share an evaluation grid, which makes the paired contrast internally valid whatever that grid is. It never records what the grid *is*, so the absolute per-home figures were not reproducible from the specification alone.

Recorded now, before any primary scoring: 5-minute inference step, `America/Los_Angeles`. These are the values every development result used, including the held-out comparison that selected the candidate — the existing choice written down rather than a new one.

Both matter beyond bookkeeping. The step sets how many points each home contributes and how much evidence each carries. The timezone determines which local hour the circadian profile is indexed by, so a displaced zone would silently misalign the mechanism under test.

The scoring runner already refuses any other grid on the primary path, so this makes the enforced values documented rather than implicit.

Correcting something I said earlier: I described this as the grid being unfrozen. It was partly frozen — the specification does require both versions to use the same one. What was missing was the value, which affects reproducibility rather than the validity of the contrast.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records the evaluation grid in the v0.3 candidate specification so the absolute per-home figures are reproducible from the spec alone.

- Documents the 5-minute inference step and `America/Los_Angeles` timezone used by all development results.
- The scoring runner already enforces these values, so this makes them explicit rather than implicit.

<sup>Written for commit f21d5142c85de36114241d7dfe4199e407dcc344. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

