### PR TITLE
Reconcile the discussion with the real-data results

### DIFF
--- a/papers/failure-aware-multimodal-behavioural-sensing/main.tex
+++ b/papers/failure-aware-multimodal-behavioural-sensing/main.tex
@@ -421,12 +421,13 @@ Missingness is not merely an efficiency problem. When record loss depends on act
 Some ambiguity is irreducible. An event-driven sensor without a heartbeat can become quieter because the resident is quieter or because events are being lost. No inference algorithm can identify which explanation is correct from that stream alone. The appropriate response is architectural: add heartbeat semantics, redundancy, or another modality, and represent residual uncertainty rather than inventing certainty.
 
 The real recordings show that this prescription is easier to state than to
-satisfy. In precisely the quiet periods this subsection identifies as
-irreducibly ambiguous, our own implementation did not represent residual
-uncertainty: the posterior drifted toward confidence because no evidence
-arrived to contradict it, which is the mechanism behind the abstention failure
-of \cref{sec:abstentionfailure}. The architectural response we recommend is
-therefore necessary but not sufficient. Representing residual uncertainty is a
+satisfy. Our own implementation did not represent residual uncertainty: stated
+confidence barely separated correct answers from incorrect ones, and was least
+reliable exactly where it was highest (\cref{sec:abstentionfailure}). That much
+is measured. Whether the failure is concentrated in the quiet, evidence-poor
+periods this subsection identifies as irreducibly ambiguous depends on the
+mechanism proposed there, which remains a hypothesis we have not isolated. The
+architectural response we recommend is therefore necessary but not sufficient. Representing residual uncertainty is a
 property a formulation must be shown to have on real data, not one it inherits
 by containing a term for it.
 

--- a/papers/failure-aware-multimodal-behavioural-sensing/main.tex
+++ b/papers/failure-aware-multimodal-behavioural-sensing/main.tex
@@ -420,6 +420,16 @@ Missingness is not merely an efficiency problem. When record loss depends on act
 
 Some ambiguity is irreducible. An event-driven sensor without a heartbeat can become quieter because the resident is quieter or because events are being lost. No inference algorithm can identify which explanation is correct from that stream alone. The appropriate response is architectural: add heartbeat semantics, redundancy, or another modality, and represent residual uncertainty rather than inventing certainty.
 
+The real recordings show that this prescription is easier to state than to
+satisfy. In precisely the quiet periods this subsection identifies as
+irreducibly ambiguous, our own implementation did not represent residual
+uncertainty: the posterior drifted toward confidence because no evidence
+arrived to contradict it, which is the mechanism behind the abstention failure
+of \cref{sec:abstentionfailure}. The architectural response we recommend is
+therefore necessary but not sufficient. Representing residual uncertainty is a
+property a formulation must be shown to have on real data, not one it inherits
+by containing a term for it.
+
 \subsection{Person attribution should be treated as a probabilistic nuisance variable}
 
 Visitor and carer contamination is not a rare edge case in realistic home monitoring. Multi-person activity-recognition work has shown that observation-to-resident association materially changes the problem \citep{wang2022multiperson}. Our narrower formulation treats occupancy context as a nuisance variable whose uncertainty attenuates ambient evidence. This is less ambitious than complete multi-resident tracking, but it is aligned with the longitudinal question: how much of the observed activity can reasonably be attributed to the person whose baseline is being updated?
@@ -437,7 +447,10 @@ The online implementation is incremental, snapshot-able, and bounded in retained
 
 The dominant limitation is external validity. The simulator was written by the same project as the estimator. Structural separation, guard tests, and distinct generative assumptions reduce circularity but cannot remove model-world bias. Simulator seeds vary stochastic realisations under one assumed world; they do not represent the structural heterogeneity of real households.
 
-Second, many inference parameters are declared rather than fitted, including emission rates, state dwell assumptions, occupancy priors, evidence weights, and alert thresholds. The resulting model is interpretable but parameter uncertainty is not propagated.
+Second, many inference parameters are declared rather than fitted, including emission rates, state dwell assumptions, occupancy priors, evidence weights, and alert thresholds. The resulting model is interpretable but parameter uncertainty is not propagated. On real recordings the cost of this is now
+measured rather than assumed: fitting emission rates removes about a third of
+the median calibration error, and declared dwell times are 3 to 9 times longer
+than measured state durations (\cref{sec:realdev}).
 
 Third, occupancy and behavioural-state layers share some evidence, notably radar and presence-beacon observations. Their errors are therefore correlated, while the current uncertainty calculation treats the stages sequentially. A joint or hierarchical model would be statistically cleaner but introduces a larger state space and should be justified by external data rather than by simulator fit.
 


### PR DESCRIPTION
Follow-up to #142, which reported the real-data development results but did not reach the Discussion. Two claims there still rest on simulator evidence the measurements contradict.

**Failure awareness changes the direction of error.** This subsection identifies the quiet event-driven sensor as the irreducibly ambiguous case — a sensor goes quiet either because the resident is quiet or because events are being lost — and prescribes representing residual uncertainty rather than inventing certainty. That is exactly the case where our own implementation fails: the posterior drifts toward confidence because no evidence arrives to contradict it, which is the mechanism behind the abstention failure. The paper was prescribing a fix for a scenario it had itself measured itself failing in, without saying so.

The added paragraph makes the prescription necessary but not sufficient, and states the general point plainly: representing residual uncertainty is a property a formulation must be *shown* to have on real data, not one it inherits by containing a term for it.

**Declared parameters.** The second limitation acknowledged that parameters are declared rather than fitted and that their uncertainty is not propagated. That cost is now measured, not assumed, so it now carries the figures — fitting emission rates removes about a third of the median calibration error, and declared dwell times run 3 to 9 times longer than measured state durations.

Compiles clean: 14 pages, no undefined references or citations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the paper's Discussion and Limitations to align with the real-data results reported in #142. The Discussion now acknowledges that our own implementation fails in exactly the ambiguous case it prescribes handling, making that prescription necessary but not sufficient; the mechanism behind the failure remains a hedged hypothesis we have not isolated. The Limitations now cite measured costs of declared parameters instead of assuming them: fitting emission rates removes about a third of the median calibration error, and declared dwell times are 3 to 9 times longer than measured state durations.

<sup>Written for commit 0866ca9a412bbc6db4d4310a56d0482841d1ee69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

