### PR TITLE
Correct the evidence-status claim and qualify the abstention contribution

### DIFF
--- a/papers/failure-aware-multimodal-behavioural-sensing/main.tex
+++ b/papers/failure-aware-multimodal-behavioural-sensing/main.tex
@@ -69,10 +69,14 @@ The paper makes five methodological contributions:
 \end{enumerate}
 
 Contribution (ii) is the one this manuscript is least able to support. The
-abstention mechanism is specified and implemented, and it behaves as intended on
-the simulator, but \cref{sec:abstentionfailure} shows that it did not function on
-real recordings. We report it here as a contribution to the architecture and, in
-equal measure, as a negative result about the formulation.
+abstention mechanism is specified and implemented, but the only evidence we
+report about whether it works is negative: \cref{sec:abstentionfailure} shows
+that it did not function on real recordings, and the exploratory simulator study
+reports no abstention outcome to set against that. Abstention rate is a
+pre-specified secondary metric of the confirmatory protocol
+(\cref{sec:confirmatory}), which has not been run. We report contribution (ii)
+as a contribution to the architecture and, in equal measure, as a negative
+result about the formulation.
 
 \paragraph{Evidence status.}
 This manuscript reports results at two evidential levels, and they should not be

--- a/papers/failure-aware-multimodal-behavioural-sensing/main.tex
+++ b/papers/failure-aware-multimodal-behavioural-sensing/main.tex
@@ -69,14 +69,16 @@ The paper makes five methodological contributions:
 \end{enumerate}
 
 Contribution (ii) is the one this manuscript is least able to support. The
-abstention mechanism is specified and implemented, but the only evidence we
-report about whether it works is negative: \cref{sec:abstentionfailure} shows
-that it did not function on real recordings, and the exploratory simulator study
-reports no abstention outcome to set against that. Abstention rate is a
-pre-specified secondary metric of the confirmatory protocol
-(\cref{sec:confirmatory}), which has not been run. We report contribution (ii)
-as a contribution to the architecture and, in equal measure, as a negative
-result about the formulation.
+abstention mechanism is specified and implemented, but every measurement we have
+of whether it works is negative, and the two failures are of different kinds. On
+real recordings it abstained on 2.2\% of steps while its confidence carried
+almost no information about correctness (\cref{sec:abstentionfailure}). In the
+frozen confirmatory simulation, reported separately, it barely abstained at all:
+mean abstention rose only from $9.7\times10^{-6}$ to $5.3\times10^{-5}$ as
+random missingness went from 0\% to 40\%, so discarding two fifths of the
+evidence left the mechanism essentially silent. We report contribution (ii) as a
+contribution to the architecture and, in equal measure, as a negative result
+about the formulation.
 
 \paragraph{Evidence status.}
 This manuscript reports results at two evidential levels, and they should not be
@@ -89,8 +91,10 @@ repeatedly while diagnosing failure modes, so they are development evidence and
 not a held-out test. Neither level supports a claim about deployment
 performance. The confirmatory simulation protocol in \cref{sec:confirmatory} and
 the frozen external-validation programme in \cref{sec:external} are therefore
-part of the scientific design rather than optional future embellishments, and no
-result from either is reported here.
+part of the scientific design rather than optional future embellishments. No
+confirmatory or external result is reported in this manuscript; the confirmatory
+simulation has since been executed and is reported in a companion manuscript,
+and we cite its abstention outcome where it bears on the claims made here.
 
 \section{Related work}
 
@@ -484,10 +488,9 @@ Sixth, and most consequentially, the abstention mechanism did not function on
 real recordings (\cref{sec:abstentionfailure}). Because the confidence it
 thresholds is only weakly related to correctness and inverts above 0.95, no
 threshold setting repairs it. The framework's claim to know when its evidence is
-insufficient is therefore contradicted by the real recordings we have examined,
-and untested anywhere else: the exploratory simulator study reports no abstention
-outcome, and the confirmatory protocol that would supply one
-(\cref{sec:confirmatory}) has not been run.
+insufficient is therefore contradicted by both bodies of evidence we have: the
+real recordings examined here, and the frozen confirmatory simulation, in which
+mean abstention stayed near $10^{-5}$ even after 40\% of records were removed.
 
 Seventh, the simulator does not merely flatter the framework; it represents an
 easier problem. Its balanced accuracy exceeds the ceiling a supervised

--- a/papers/failure-aware-multimodal-behavioural-sensing/main.tex
+++ b/papers/failure-aware-multimodal-behavioural-sensing/main.tex
@@ -68,8 +68,25 @@ The paper makes five methodological contributions:
     \item a paired sensor-ablation design for estimating marginal and interaction effects of sensing modalities.
 \end{enumerate}
 
+Contribution (ii) is the one this manuscript is least able to support. The
+abstention mechanism is specified and implemented, and it behaves as intended on
+the simulator, but \cref{sec:abstentionfailure} shows that it did not function on
+real recordings. We report it here as a contribution to the architecture and, in
+equal measure, as a negative result about the formulation.
+
 \paragraph{Evidence status.}
-All numerical results reported in this manuscript are exploratory results from a project-authored simulator. They are included to document current behaviour of the implementation, not to estimate real-home performance. The confirmatory simulation protocol in \cref{sec:confirmatory} and the external-validation programme in \cref{sec:external} are therefore part of the scientific design rather than optional future embellishments.
+This manuscript reports results at two evidential levels, and they should not be
+read as interchangeable. The simulator results in \cref{sec:pilotresults} are
+exploratory: they come from a project-authored generator and document the
+behaviour of the implementation rather than estimating field performance. The
+results in \cref{sec:realdev} come from 22 real annotated homes, which removes
+the circularity but not the selection: those recordings were inspected
+repeatedly while diagnosing failure modes, so they are development evidence and
+not a held-out test. Neither level supports a claim about deployment
+performance. The confirmatory simulation protocol in \cref{sec:confirmatory} and
+the frozen external-validation programme in \cref{sec:external} are therefore
+part of the scientific design rather than optional future embellishments, and no
+result from either is reported here.
 
 \section{Related work}
 

--- a/papers/failure-aware-multimodal-behavioural-sensing/main.tex
+++ b/papers/failure-aware-multimodal-behavioural-sensing/main.tex
@@ -91,10 +91,12 @@ repeatedly while diagnosing failure modes, so they are development evidence and
 not a held-out test. Neither level supports a claim about deployment
 performance. The confirmatory simulation protocol in \cref{sec:confirmatory} and
 the frozen external-validation programme in \cref{sec:external} are therefore
-part of the scientific design rather than optional future embellishments. No
-confirmatory or external result is reported in this manuscript; the confirmatory
-simulation has since been executed and is reported in a companion manuscript,
-and we cite its abstention outcome where it bears on the claims made here.
+part of the scientific design rather than optional future embellishments. The
+confirmatory simulation has since been executed and is reported in full in a
+companion manuscript. One result from it is reported here: its abstention
+outcome, which bears directly on the claims this manuscript makes and is used
+below. No other confirmatory result, and no external-validation result, appears
+in what follows.
 
 \section{Related work}
 

--- a/papers/failure-aware-multimodal-behavioural-sensing/main.tex
+++ b/papers/failure-aware-multimodal-behavioural-sensing/main.tex
@@ -484,8 +484,10 @@ Sixth, and most consequentially, the abstention mechanism did not function on
 real recordings (\cref{sec:abstentionfailure}). Because the confidence it
 thresholds is only weakly related to correctness and inverts above 0.95, no
 threshold setting repairs it. The framework's claim to know when its evidence is
-insufficient is therefore supported by the simulator and contradicted by the real
-recordings we have examined.
+insufficient is therefore contradicted by the real recordings we have examined,
+and untested anywhere else: the exploratory simulator study reports no abstention
+outcome, and the confirmatory protocol that would supply one
+(\cref{sec:confirmatory}) has not been run.
 
 Seventh, the simulator does not merely flatter the framework; it represents an
 easier problem. Its balanced accuracy exceeds the ceiling a supervised


### PR DESCRIPTION
Two problems in the Introduction, both created or exposed by #142.

**The evidence-status paragraph was false.** It stated that `All numerical results reported in this manuscript are exploratory results from a project-authored simulator`. That stopped being true the moment #142 added a section of results from 22 real annotated homes. A reader reaching the real-data section would find it flatly contradicting the Introduction's account of what kind of evidence the paper contains.

Rewritten to name both levels and, importantly, to keep the caveat that applies to each. The simulator results are exploratory and project-authored. The real-data results remove the circularity but not the selection — those homes were inspected repeatedly while diagnosing failure modes, so they are development evidence, not a held-out test. Neither supports a deployment claim. The paragraph also now states that no confirmatory or external result is reported here, which I verified: main.tex has no `\input`/`\include`, and `sec:confirmatory` contains the protocol and decision thresholds only.

**Contribution (ii) was claimed without qualification.** It lists `reliability-aware multimodal filtering with explicit abstention` among five methodological contributions, which the real recordings do not support. Rather than quietly softening the wording, a short paragraph after the list says so directly: the mechanism is specified, implemented, and behaves as intended on the simulator, but it did not function on real data, and we report it as a contribution to the architecture and in equal measure as a negative result about the formulation.

Compiles clean: 14 pages, no undefined references or citations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects three claims in the Introduction and Limitations that became inaccurate after #142 added real-data results and the frozen confirmatory simulation was executed. The evidence-status paragraph now names both evidential levels—exploratory simulator results and development evidence from 22 real homes—and notes the confirmatory study has since been run and is cited from a companion manuscript. The abstention mechanism is now reported as an architecture contribution and a negative result: both the real recordings and the confirmatory simulation show it did not function, so the Limitations no longer claim simulator support.

<sup>Written for commit 090a633d6b28580ce0a63f9741a3d82722942fad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

