### PR TITLE
Address the confirmatory manuscript review findings

### DIFF
--- a/papers/failure-aware-multimodal-behavioural-sensing/manuscript_confirmatory.tex
+++ b/papers/failure-aware-multimodal-behavioural-sensing/manuscript_confirmatory.tex
@@ -29,14 +29,14 @@
 \title{Failure-Aware Multimodal Behavioural Sensing:\\
 Probabilistic State Inference, Person Attribution, and Sensor Reduction in Smart Homes}
 \author{Diogo Ribeiro\\
-\small \textit{Faculty of Media Arts and Design, Technical University of Porto}}
+\small \textit{ESMAD, Instituto Politécnico do Porto}}
 \date{}
 
 \begin{document}
 \maketitle
 
 \begin{abstract}
-Ambient assisted-living systems infer behaviour from sparse, heterogeneous, and imperfect sensor streams, yet sensor activation is often treated too directly as behavioural truth. We present a failure-aware multimodal framework in which sensor events are uncertain observations of latent behavioural state. The framework combines hardware-neutral observation semantics, sensor-health reliability, occupancy-aware resident attribution, continuous-time latent-state filtering, adaptive baselines, restrained alerting, and paired sensor ablation. We evaluated five pre-specified hypotheses in a frozen confirmatory simulation with $N=200$ paired household trajectories; the run passed its Monte Carlo precision and provenance gates. Random missingness produced graded loss of balanced accuracy, although abstention did not increase materially. The frozen five-sensor deployment failed non-inferiority against the ten-sensor deployment by a large margin: the balanced-accuracy gap was $0.1548$ (95\% CI $[0.1531,0.1564]$) against a $0.02$ margin. A secondary eight-sensor configuration was much closer to the full deployment, with a gap of $0.00529$. Occupancy-aware attribution helped under several contamination regimes, particularly carer-related scenarios, but harmed balanced accuracy when wearable and beacon evidence were unavailable. Failure-aware reliability weighting improved log loss while worsening balanced accuracy, Brier score, and calibration error, demonstrating a genuine scoring trade-off rather than uniform dominance. All four pre-specified sensor-interaction terms were positive. These results are simulator-derived and are not estimates of field performance. The contribution is therefore methodological and diagnostic: fewer sensors can preserve information, but aggressive reduction and reliability weighting have failure modes that must remain visible rather than being hidden by post-hoc model selection.
+Ambient assisted-living systems infer behaviour from sparse, heterogeneous, and imperfect sensor streams, yet sensor activation is often treated too directly as behavioural truth. We present a failure-aware multimodal framework in which sensor events are uncertain observations of latent behavioural state. The framework combines hardware-neutral observation semantics, sensor-health reliability, occupancy-aware resident attribution, continuous-time latent-state filtering, adaptive baselines, restrained alerting, and paired sensor ablation. We evaluated five pre-specified hypotheses in a frozen confirmatory simulation with $N=200$ paired household trajectories; the run passed its Monte Carlo precision and provenance gates. Random missingness produced graded loss of balanced accuracy, although abstention did not increase materially. The frozen five-sensor deployment failed non-inferiority against the ten-sensor deployment by a large margin: the balanced-accuracy gap was $0.1548$ (95\% CI $[0.1531,0.1564]$) against a $0.02$ margin. A secondary eight-sensor configuration was much closer to the full deployment, with a gap of $0.00529$. Occupancy-aware attribution helped under several contamination regimes, particularly carer-related scenarios, but harmed balanced accuracy when wearable and beacon evidence were unavailable. Failure-aware reliability weighting improved log loss while worsening balanced accuracy, Brier score, and calibration error, demonstrating a genuine scoring trade-off rather than uniform dominance. All four pre-specified sensor-interaction terms were positive. These results are simulator-derived and are not estimates of field performance. Development-stage evidence from 22 real annotated homes, summarised here rather than omitted, indicates that the simulator represents an easier problem than the instrumentation supports --- median balanced accuracy $0.420$ against a $0.607$ supervised ceiling on the same sensor information --- and independently corroborates the H1 abstention finding. The contribution is therefore methodological and diagnostic: fewer sensors can preserve information, but aggressive reduction and reliability weighting have failure modes that must remain visible rather than being hidden by post-hoc model selection.
 \end{abstract}
 
 \noindent\textbf{Keywords:} ambient assisted living; behavioural sensing; sensor fusion; uncertainty; smart homes; missing data; multi-resident activity recognition; sensor ablation
@@ -115,6 +115,30 @@ Positive $I_{ij}$ indicates complementarity under this definition.
 \section{Experimental design}
 \label{sec:experiments}
 
+\subsection{Metrics}
+\label{sec:metrics}
+
+Balanced accuracy is the mean per-class recall over the states present in the
+truth, which prevents a model that always predicts the majority state from
+scoring well; macro F1 is the unweighted mean F1 over the same classes.
+Multiclass log loss and the multiclass Brier score are computed from the full
+posterior rather than from the argmax label. Expected calibration error uses ten
+equal-width confidence bins,
+\begin{equation}
+\mathrm{ECE}=\sum_{b=1}^{10}\frac{n_b}{n}\big|\mathrm{acc}(b)-\mathrm{conf}(b)\big|,
+\end{equation}
+where $n_b$ is the number of estimates whose leading-state confidence falls in
+bin $b$, and $\mathrm{acc}(b)$ and $\mathrm{conf}(b)$ are the mean correctness
+and mean confidence within it.
+
+The abstention convention matters for reading H1 and is applied consistently: a
+reported \textsc{unknown} is never scored correct, because \textsc{unknown} is
+never a true label. Abstention therefore costs recall, and abstention rate is
+reported alongside the accuracy metrics so that a model which declines usefully
+can be distinguished from one that is simply wrong.
+
+\subsection{Simulator and frozen design}
+
 The simulator generates longitudinal household trajectories with known latent state, resident location, sleep, outings, visitors, carer visits, and sensor observations. The generative process is deliberately structurally different from the estimator. Sensor degradation is injected separately from behavioural generation, allowing paired counterfactual comparisons on the same household trajectory.
 
 The confirmatory study was frozen before results were examined. The independent replication unit is one simulated household trajectory, with initial production size $N=200$ and seeds
@@ -123,13 +147,56 @@ s_i=10000+4i,\qquad i=0,\ldots,N-1.
 \end{equation}
 Replication could increase only for the pre-specified Monte Carlo precision criterion, up to $N=1000$, without inspecting hypothesis direction or changing the design. The target was maximum H2 balanced-accuracy MCSE $\leq0.002$ across the pre-specified reduced configurations. The observed maximum MCSE was $0.001125$, so the experiment stopped at the initial $N=200$.
 
-The frozen hypotheses were: H1, graceful degradation across 0\%, 5\%, 10\%, 20\%, and 40\% random missingness; H2, non-inferiority of a five-sensor radar/door/bed/wearable deployment relative to the ten-sensor deployment, with margin $0.02$ on balanced accuracy; H3, scenario-specific attribution value under visitor/carer contamination; H4, failure-aware versus health-naive reliability weighting on identical degraded observations; and H5, non-zero pre-specified sensor interactions. All uncertainty calculations are over households, never time points. A negative hypothesis result remains scientifically valid if the frozen provenance and precision gates pass.
+The five frozen hypotheses, their contrasts, and their pre-specified criteria
+are given in \cref{tab:hypotheses}. All uncertainty calculations are over
+households, never time points. A negative hypothesis result remains
+scientifically valid if the frozen provenance and precision gates pass.
+
+\begin{table}[t]
+\centering
+\small
+\caption{Frozen confirmatory hypotheses. Only H2 carried a numeric decision
+gate; the remaining hypotheses were pre-specified as directional, with the
+secondary metrics supplying uncertainty and safety context rather than
+additional gates.}
+\label{tab:hypotheses}
+\begin{tabular}{@{}lp{3.5cm}p{3.6cm}p{3.1cm}@{}}
+\toprule
+& Frozen contrast & Primary metric & Pre-specified criterion \\
+\midrule
+H1 & Random record loss at $0$, $5$, $10$, $20$, $40\%$ & Balanced accuracy, with log loss, Brier, ECE, abstention rate & Graded rather than cliff-like loss \\
+H2 & Five-sensor versus ten-sensor deployment, paired by seed & $D_{H2}=\mathrm{BA}_{\mathrm{full}}-\mathrm{BA}_{\mathrm{reduced}}$ & $U_{0.95}(D_{H2})<0.02$ \\
+H3 & Occupancy-aware versus naive attribution, eight contamination scenarios & Balanced accuracy and probabilistic scores & Scenario-specific benefit \\
+H4 & Failure-aware versus health-naive weighting on identical degraded records & Balanced accuracy, log loss, Brier, ECE & Direction of paired difference \\
+H5 & Four pre-specified sensor pairs & Interaction $I_{ij}$ & Non-zero \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+\paragraph{Frozen design parameters.}
+Each replication simulates 70 days of a single household on a 15-minute
+inference grid. The latent ontology has seven states: away, home-active,
+home-inactive, sleeping, bed-awake, bathroom-activity, and kitchen-activity. The
+full deployment comprises ten sensors: \texttt{front\_door}; four motion sensors
+in bedroom, bathroom, kitchen, and living room; \texttt{fridge\_contact};
+\texttt{bed\_pressure}; \texttt{living\_radar}; \texttt{wearable\_motion}; and
+\texttt{resident\_beacon}. The frozen H2 reduced configuration retains
+\texttt{front\_door}, \texttt{living\_radar}, \texttt{bed\_pressure},
+\texttt{wearable\_motion}, and \texttt{resident\_beacon}; the secondary
+eight-sensor configuration is the six object sensors plus
+\texttt{wearable\_motion} and \texttt{resident\_beacon}. The H4 degraded regime
+applies 30\% random record loss together with a 14-day \texttt{bed\_pressure}
+outage beginning on day 35, and the health-naive control sees exactly the same
+observations with all reliability weights forced to one, so the contrast
+isolates the use of health reliability rather than the missingness itself. All
+intervals are 95\% household-paired bootstrap intervals over 5000 resamples.
 
 \input{confirmatory_results.tex}
 
 \section{Discussion}
 
 \subsection{Graceful degradation does not imply appropriate abstention}
+\label{sec:h1abstention}
 
 The H1 result separates two ideas that are often conflated. Balanced accuracy degrades gradually as random records are removed, which is preferable to a cliff-like failure. However, the inference system does not respond to this loss by abstaining materially more often, and the probabilistic metrics are not monotone in the intuitive direction. In particular, log loss improves while discrimination worsens. The architectural rule that missing sensors should not vote for inactivity is therefore necessary but not sufficient for an uncertainty mechanism that degrades in the way a downstream decision-maker might expect. Coverage-aware abstention remains a specific target for external validation and future model revision.
 
@@ -160,16 +227,72 @@ Second, several inference parameters are declared rather than estimated from ind
 
 Finally, the confirmatory intervals are precise conditional on the simulator and paired household design; precision does not imply transportability. The narrow H2 interval establishes that the five-sensor gap is not Monte Carlo noise under this model world. It does not establish the size of that gap in real homes.
 
+\section{Development evidence from real recordings}
+\label{sec:realdev}
+
+This manuscript reports the frozen confirmatory simulation, and the results
+above are simulator-derived by construction. Development work on real
+recordings has since been carried out and is reported in full in the companion
+development manuscript. We summarise it here rather than omit it, because two of
+its findings bear directly on how the confirmatory results should be read, and
+because a confirmatory paper reporting only the simulator would present a more
+favourable picture than this project's own evidence supports.
+
+The evidence is development-grade and cannot be promoted to confirmatory: the 22
+annotated single-resident homes involved were inspected repeatedly while
+diagnosing failure modes, so they are not a held-out test. Nothing in this
+section revises a frozen confirmatory outcome, and no result reported here was
+used to select the confirmatory design, which was frozen first.
+
+Two findings matter for this manuscript. First, median balanced accuracy on
+those recordings was $0.420$, against $0.816$ in simulation, while a supervised
+classifier given the same sensor information reached only $0.607$. The simulator
+therefore represents an easier problem than the instrumentation supports for any
+method, rather than an optimistic estimate of the same quantity. The
+transportability caveat in \cref{sec:limitations} is consequently stronger than a
+statement about interval width: the gap lies in the problem, not only in the
+precision.
+
+Second, the real recordings corroborate the H1 abstention finding of
+\cref{sec:h1abstention} by an independent route. In simulation the mechanism
+barely fired at all, with mean abstention rates of $9.7\times10^{-6}$ under no
+missingness and $5.3\times10^{-5}$ at 40\%. On real recordings it did fire, on
+$2.2\%$ of steps, but its confidence carried almost no information about
+correctness: correct and incorrect answers were separated by $0.073$, and the
+relationship inverted above $0.95$, so no threshold setting repairs it. The two
+failures differ in character --- near-silence in simulation, uninformative
+confidence on real data --- but they agree on the conclusion, and it is the
+conclusion this framework can least afford: the system does not know when its
+evidence is insufficient.
+
 \section{External validation}
 \label{sec:external}
 
 External validation should proceed without redesigning the model around the simulator results. CASAS provides annotated smart-home datasets spanning single-resident and multi-resident settings \citep{cook2013casas}, while ARAS provides month-long labelled recordings from two multi-resident homes \citep{alemdar2013aras}. These datasets can test state recognition, contamination, temporal generalisation, and robustness to real sensor sparsity.
 
-The external-validation workflow should freeze the ontology, observation semantics, metrics, and principal hypotheses; implement dataset adapters without modifying downstream inference; fit only parameters explicitly designated as trainable using household-separated training data; evaluate on held-out homes or held-out periods rather than random time points; and report discrimination, calibration, abstention, attribution evidence quality, and failure/coverage strata. The relevant question is not whether the simulator numbers reproduce exactly, but whether the qualitative findings survive: graded discrimination loss, conditional attribution value, a sensor-information frontier, non-additive sensor value, and the possibility that failure-aware weighting improves one proper score while worsening others.
+The external-validation workflow should freeze the ontology, observation semantics, metrics, and principal hypotheses; implement dataset adapters without modifying downstream inference; fit only parameters explicitly designated as trainable using household-separated training data; evaluate on held-out homes or held-out periods rather than random time points; and report discrimination, calibration, abstention, attribution evidence quality, and failure/coverage strata. A primary external cohort of single-resident homes disjoint from the development panel has since been frozen with per-home checksums and screening provenance, together with the candidate configuration and a one-shot scoring runner; that scoring has not been executed at the time of writing. The relevant question is not whether the simulator numbers reproduce exactly, but whether the qualitative findings survive: graded discrimination loss, conditional attribution value, a sensor-information frontier, non-additive sensor value, and the possibility that failure-aware weighting improves one proper score while worsening others.
 
 \section{Reproducibility and software}
 
-The confirmatory experiment is frozen to Git revision \texttt{bd5a9b10068b69fc75cc6f806904430633ce7408}, configuration SHA-256 \texttt{7b48ec89155f78ae7965ac59c9b17a6bf164889ed7f38194c35ba1576aedfae4}, Python 3.11.16, and the pinned numerical environment recorded in the accepted artifact. The original production run generated 40 immutable shards; a later merge-only recovery reused those shards after a workflow-path bug prevented the first merge from starting. The recovered merged artifact passed the original frozen validator without rerunning any household simulation. A repository-retained result snapshot records the validator output, accepted summaries, workflow identifiers, artifact digest, and file-level hashes.
+The confirmatory experiment is frozen to the provenance in
+\cref{tab:provenance}, together with the pinned numerical environment recorded in
+the accepted artifact.
+
+\begin{table}[h]
+\centering
+\small
+\caption{Frozen provenance of the accepted confirmatory run.}
+\label{tab:provenance}
+\begin{tabular}{@{}l p{7.2cm}@{}}
+\toprule
+Git revision & \texttt{bd5a9b10\allowbreak 068b69fc\allowbreak 75cc6f80\allowbreak 69044306\allowbreak 33ce7408} \\
+Configuration SHA-256 & \texttt{7b48ec89\allowbreak 155f78ae\allowbreak 7965ac59\allowbreak c9b17a6b\allowbreak f164889e\allowbreak d7f38194\allowbreak c35ba157\allowbreak 6aedfae4} \\
+Python & 3.11.16 \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+The original production run generated 40 immutable shards; a later merge-only recovery reused those shards after a workflow-path bug prevented the first merge from starting. The recovered merged artifact passed the original frozen validator without rerunning any household simulation. A repository-retained result snapshot records the validator output, accepted summaries, workflow identifiers, artifact digest, and file-level hashes.
 
 The accepted result remains simulator-derived. No field-performance claim is inferred from the validation status, and no secondary H2 sensor subset is promoted to replace the frozen primary comparison.
 
@@ -177,7 +300,7 @@ The accepted result remains simulator-derived. No field-performance claim is inf
 
 Failure-aware multimodal behavioural sensing is not validated by a single accuracy number. The frozen simulation instead reveals where the architecture succeeds and where its intuitions are incomplete. Random missingness produces graded discrimination loss, but the current abstention mechanism does not respond strongly to declining evidence. The selected five-sensor deployment is decisively not non-inferior to the ten-sensor system, although an eight-sensor secondary configuration preserves much more information. Occupancy-aware attribution helps in several contaminated scenarios but can become harmful when resident-specific evidence disappears. Failure-aware reliability weighting improves log loss while worsening balanced accuracy, Brier score, and calibration error. Sensor interactions are consistently positive for the four pre-specified pairs.
 
-These mixed and negative findings are the main value of the confirmatory study. They narrow the claims that should be carried into real-home evaluation and prevent a simulator from being used merely to certify a preferred architecture. The next scientific boundary is therefore external validation on held-out real households, with the present negative H2 result and metric disagreements preserved rather than tuned away.
+These mixed and negative findings are the main value of the confirmatory study. They narrow the claims that should be carried into real-home evaluation and prevent a simulator from being used merely to certify a preferred architecture. The next scientific boundary is therefore external validation on held-out real households, with the present negative H2 result and metric disagreements preserved rather than tuned away. That boundary is no longer entirely ahead of us. Development evidence on 22 real homes (\cref{sec:realdev}) already indicates that the simulator represents an easier problem than real instrumentation supports, and independently corroborates the H1 finding that abstention does not track evidence quality. The frozen external cohort remains unscored, and it is the abstention claim, rather than the accuracy figures, that most needs it.
 
 \printbibliography
 


### PR DESCRIPTION
Acts on four of the five reviewer findings. The fifth is a decision for you, not a code change.

**High — the submission candidate omitted the real-recording evidence.** Correct, and the omission ran through abstract, external validation, and conclusion, all of which framed real-home work as entirely future. Adds `Development evidence from real recordings`, which states the scope decision explicitly rather than leaving the exclusion implicit: the evidence is development-grade and cannot be promoted, since those 22 homes were inspected repeatedly while diagnosing failure modes; nothing in it revises a frozen outcome; and none of it was used to select the confirmatory design, which was frozen first.

Two findings carry into this manuscript. The supervised ceiling of 0.607 against a 0.420 median makes the transportability caveat stronger than a statement about interval width — the gap is in the problem, not only the precision. And the real recordings corroborate the H1 abstention result by an independent route. That connection is the most valuable thing here and the manuscript was missing it: in simulation the mechanism was near-silent (mean abstention 9.7e-6 at no missingness, 5.3e-5 at 40%); on real data it fired on 2.2% of steps but its confidence was uninformative (separation 0.073, inverting above 0.95). Different failures, same conclusion — the system does not know when its evidence is insufficient.

**Medium — too compressed to audit without reading code.** Adds a `Metrics` subsection defining balanced accuracy, macro F1, log loss, Brier, and ECE (ten equal-width bins, with the formula), plus the abstention convention, which matters because a reported UNKNOWN is never scored correct and therefore costs recall. Replaces the collapsed hypotheses paragraph with a design table and a frozen-parameters paragraph covering the ontology, the ten-sensor set and both reduced configurations, the H4 degraded regime, and the bootstrap. All values were read from `experiments/config.json` rather than paraphrased. The table also records something previously implicit: only H2 carried a numeric decision gate.

**Medium — affiliation.** Set to `ESMAD, Instituto Politécnico do Porto`, matching CITATION.cff, .zenodo.json, and the esmad.ipp.pt contact address. Please confirm the preferred rendering. Note `main.tex` still carries `Affiliation to be confirmed before submission`, which I left alone as a deliberate placeholder.

**Low — overfull boxes.** The two hashes now sit in a small provenance table with explicit break points. Verified programmatically that both reconstruct byte-identically once the break hints are stripped. Overfull box count is now 0.

**High — `papers/` tracked despite .gitignore.** Left untouched: whether the manuscripts are public is your call, not a change I should make unilaterally. Flagging only the coupling you asked about — the Reproducibility section states that a repository-retained snapshot records the validator output and hashes, and that sentence stops being true if `papers/` is untracked without relocating the bundle.

Clean build from a fresh copy: 11 pages, 0 undefined references, 0 undefined citations, 0 overfull boxes, 0 unresolved `??` in the rendered PDF.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Addresses four of the five confirmatory manuscript review findings; the fifth, whether `papers/` stays tracked, is left to the author's call.

- Adds a real-recordings section stating its scope explicitly: the 22 development homes can't be promoted, the supervised ceiling of 0.607 versus a 0.420 median strengthens the transportability caveat, and real data corroborates the H1 abstention result through an independent route.
- Adds a `Metrics` subsection (balanced accuracy, macro F1, log loss, Brier, ECE, and the convention that a reported UNKNOWN is never scored correct) and replaces the collapsed hypotheses paragraph with a design table plus frozen parameters read from `experiments/config.json`.
- Changes the affiliation to `ESMAD, Instituto Politécnico do Porto`; the placeholder in `main.tex` remains for confirmation.
- Moves the two hashes into a provenance table with explicit break points, verified to reconstruct byte-identically, bringing the overfull box count to 0.
- Notes that the external-validation section now records a frozen, not-yet-scored primary cohort.

<sup>Written for commit e2ed7cf782e006d87ebaa6e7a831cad7371b000b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

