### PR TITLE
Record that RQ2's falsification condition has been met

### DIFF
--- a/docs/RESEARCH_QUESTIONS.md
+++ b/docs/RESEARCH_QUESTIONS.md
@@ -65,12 +65,30 @@ all scored with calibration alongside accuracy.
 calibration error stays bounded, and abstention rising when evidence
 genuinely disappears.
 
-**Current state.** Balanced accuracy 0.858 → 0.748 across 0–40% loss with
-calibration error 0.046 → 0.079. Under total blackout the system abstains.
+**Current state.** On the simulator, balanced accuracy 0.858 → 0.748 across
+0–40% loss with calibration error 0.046 → 0.079, and under total blackout the
+system abstains.
 
 **What would falsify it.** Any regime where confidence stays high while
 accuracy collapses. This is the failure mode the platform exists to prevent,
 and it is tested adversarially rather than assumed.
+
+**This falsification condition has been met.** On real recordings, over 60,948
+scored steps, stated confidence separates correct from incorrect answers by only
++0.073, and the most confident band (0.95–1.00) is *less* accurate at 0.561 than
+the band beneath it at 0.653 while covering 39% of all steps. That is confidence
+staying high while accuracy collapses, measured rather than hypothesised, and no
+threshold repairs it: raising the bar discards the pipeline's best band and keeps
+the saturated one. The frozen confirmatory simulation agrees by a different
+route — mean abstention rose only from 9.7e-06 to 5.3e-05 as missingness went
+from 0% to 40%, so the mechanism barely responds to evidence disappearing.
+
+RQ2 is therefore answered negatively on the evidence available. The architecture
+still prevents the specific failure it was designed against — a failed sensor
+contributes no state preference and never votes for inactivity — but that is a
+weaker property than RQ2 asks about, and the system does not currently fail
+safely in the sense defined here. See [real_data.md](real_data.md) for the
+per-band figures and [limitations.md](limitations.md).
 
 ## RQ3 — How much does person attribution matter?
 


### PR DESCRIPTION
While reconciling the manuscripts against the real-data results I checked whether the same error had been left in the repo docs. It had, in the place where it matters most.

`RESEARCH_QUESTIONS.md` RQ2 asks whether the system fails safely rather than silently, and states its own falsification condition: *any regime where confidence stays high while accuracy collapses.* The project has since measured exactly that. Over 60,948 scored steps on real recordings, confidence separates correct from incorrect answers by +0.073, and the most confident band (0.95–1.00) is *less* accurate at 0.561 than the band beneath it at 0.653 — while covering 39% of all steps. The frozen confirmatory simulation agrees by a different route: mean abstention rose only from 9.7e-06 to 5.3e-05 as missingness went from 0% to 40%.

RQ2's `Current state` still reported only the simulator sweep, so the document asserted a falsification test that its own project had already failed, with the evidence sitting in `real_data.md` two files away.

Now records the negative answer, keeps the simulator numbers but labels them as such, and draws the distinction that survives: the architecture does still prevent the specific failure it was designed against — a failed sensor contributes no state preference and never votes for inactivity — but that is a weaker property than RQ2 asks about. The file's preamble says questions are stated so a negative result is publishable and recognisable, so this is the document working as intended rather than an exception to it.

All figures verified against `real_data.md` and `accepted_summary.json` rather than quoted from memory. Docs-only, so the test matrix skips.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `docs/RESEARCH_QUESTIONS.md` so RQ2's documented answer changes from the simulator-only result to a negative one, recording that the falsification condition has been met.

The real-data figures over 60,948 scored steps show confidence separates correct from incorrect answers by only +0.073, and the most confident band (0.95–1.00) is less accurate (0.561) than the band beneath it (0.653) while covering 39% of all steps. The simulator numbers stay but are now labeled as simulator results. The architecture still prevents a failed sensor from voting for inactivity, but that is a weaker property than RQ2 asks about.

<sup>Written for commit 9f95cbc287eb75bca414c2f83f4319a9412665ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

