### PR TITLE
feat: adopt DataExcept at sensor ingestion boundaries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ dependencies = [
     "pyyaml>=6.0",
     "tqdm>=4.60.0",
     "joblib>=1.1.0",
+    "DataExcept>=1.3,<2.0",
 ]
 
 [project.optional-dependencies]

--- a/sensor_modeling/data/exceptions.py
+++ b/sensor_modeling/data/exceptions.py
@@ -1,0 +1,40 @@
+"""Sensor-ingestion exceptions with DataExcept taxonomy and legacy compatibility."""
+
+from __future__ import annotations
+
+from dataexcept import (
+    DataFormatError,
+    DataLoadingError,
+    DataValidationError,
+    DependencyError,
+    MissingDataError,
+)
+
+
+class SensorDataLoadingError(DataLoadingError, ValueError):
+    """Data loading failure that remains catchable as the legacy ``ValueError``."""
+
+
+class SensorDataFormatError(DataFormatError, ValueError):
+    """Malformed sensor payload that remains catchable as ``ValueError``."""
+
+
+class SensorDataValidationError(DataValidationError, ValueError):
+    """Invalid sensor value that remains catchable as ``ValueError``."""
+
+
+class SensorMissingDataError(MissingDataError, ValueError):
+    """Missing required sensor field that remains catchable as ``ValueError``."""
+
+
+class SensorDependencyError(DependencyError, ImportError):
+    """Missing ingestion dependency that remains catchable as ``ImportError``."""
+
+
+__all__ = [
+    "SensorDataFormatError",
+    "SensorDataLoadingError",
+    "SensorDataValidationError",
+    "SensorDependencyError",
+    "SensorMissingDataError",
+]

--- a/sensor_modeling/data/loaders.py
+++ b/sensor_modeling/data/loaders.py
@@ -8,7 +8,7 @@ from collections.abc import Generator, Iterable, Mapping
 from os import PathLike
 
 import pandas as pd
-from dataexcept import DataExceptError
+from dataexcept import DataExceptError, DataLoadingError
 
 from sensor_modeling.data.exceptions import (
     SensorDataFormatError,
@@ -55,8 +55,12 @@ def load_csv(
     """
     try:
         df = read_sensor_csv(path, timestamp_col=timestamp_col, **kwargs)
-    except DataExceptError as exc:
+    except DataLoadingError as exc:
         logger.error("Failed to read CSV %s: %s", path, exc)
+        legacy = ValueError(f"Unable to read CSV file: {path}")
+        raise SensorDataLoadingError(str(path), legacy) from exc
+    except DataExceptError as exc:
+        logger.error("Failed to validate CSV %s: %s", path, exc)
         raise
     logger.info("Loaded CSV with shape %s from %s", df.shape, path)
     return SensorDataset(df)

--- a/sensor_modeling/data/loaders.py
+++ b/sensor_modeling/data/loaders.py
@@ -8,6 +8,14 @@ from collections.abc import Generator, Iterable, Mapping
 from os import PathLike
 
 import pandas as pd
+from dataexcept import (
+    DataExceptError,
+    DataFormatError,
+    DataLoadingError,
+    DataValidationError,
+    DependencyError,
+    MissingDataError,
+)
 
 from sensor_modeling.utils.data_io import SensorDataset, read_sensor_csv
 
@@ -18,7 +26,11 @@ def _parse_timestamps(values: object, field_name: str) -> pd.Series:
     """Parse timestamp values and reject missing or invalid entries."""
     timestamps = pd.to_datetime(values, errors="coerce")
     if pd.isna(timestamps).any():
-        raise ValueError(f"Timestamp field '{field_name}' contains invalid timestamps")
+        raise DataValidationError(
+            field_name,
+            "<invalid timestamp>",
+            f"Timestamp field '{field_name}' contains invalid timestamps",
+        )
     return timestamps
 
 
@@ -43,15 +55,9 @@ def load_csv(
     """
     try:
         df = read_sensor_csv(path, timestamp_col=timestamp_col, **kwargs)
-    except (
-        OSError,
-        TypeError,
-        UnicodeError,
-        ValueError,
-        pd.errors.ParserError,
-    ) as exc:
+    except DataExceptError as exc:
         logger.error("Failed to read CSV %s: %s", path, exc)
-        raise ValueError(f"Unable to read CSV file: {path}") from exc
+        raise
     logger.info("Loaded CSV with shape %s from %s", df.shape, path)
     return SensorDataset(df)
 
@@ -65,7 +71,7 @@ def load_json(
             records = json.load(f)
     except (OSError, UnicodeError, json.JSONDecodeError) as exc:
         logger.error("Failed to read JSON %s: %s", path, exc)
-        raise ValueError(f"Unable to read JSON file: {path}") from exc
+        raise DataLoadingError(str(path), exc) from exc
 
     df = _records_to_frame(records, timestamp_field=timestamp_field)
     logger.info("Loaded JSON with shape %s from %s", df.shape, path)
@@ -75,19 +81,26 @@ def load_json(
 def _records_to_frame(records: object, timestamp_field: str) -> pd.DataFrame:
     """Convert JSON records into a timestamp-indexed DataFrame."""
     if not isinstance(records, list):
-        raise ValueError("JSON file must contain a list of records")
+        raise DataFormatError(["JSON list of records"], type(records).__name__)
     if any(not isinstance(record, Mapping) for record in records):
-        raise ValueError("Invalid JSON structure for tabular data")
+        raise DataFormatError(
+            ["JSON list of object records"],
+            "list containing non-object entries",
+        )
 
     try:
         df = pd.DataFrame(records)
     except (TypeError, ValueError) as exc:
         logger.error("JSON structure invalid: %s", exc)
-        raise ValueError("Invalid JSON structure for tabular data") from exc
+        raise DataFormatError(
+            ["JSON list of object records"],
+            f"invalid tabular structure ({exc})",
+        ) from exc
 
     if timestamp_field not in df.columns:
-        raise ValueError(
-            f"Timestamp field '{timestamp_field}' missing from JSON records"
+        raise MissingDataError(
+            timestamp_field,
+            f"Timestamp field '{timestamp_field}' missing from JSON records",
         )
 
     df[timestamp_field] = _parse_timestamps(df[timestamp_field], timestamp_field)
@@ -99,19 +112,24 @@ def load_hdf5(path: str | PathLike[str], key: str = "data") -> SensorDataset:
     try:
         import h5py
     except ImportError as exc:  # pragma: no cover - dependency is installed in CI
-        raise ImportError("h5py is required for HDF5 support") from exc
+        raise DependencyError("h5py", "h5py is required for HDF5 support") from exc
 
     try:
         with h5py.File(path, "r") as h5:
             if key not in h5:
-                raise ValueError(f"Dataset '{key}' not found in HDF5 file")
+                raise MissingDataError(
+                    key,
+                    f"Dataset '{key}' not found in HDF5 file",
+                )
             data = pd.DataFrame(h5[key][:])
             if "timestamp" in h5[key].attrs:
-                ts = pd.to_datetime(h5[key].attrs["timestamp"])
-                data.index = ts
+                data.index = _parse_timestamps(
+                    h5[key].attrs["timestamp"],
+                    "timestamp",
+                )
     except OSError as exc:
         logger.error("Failed to read HDF5 %s: %s", path, exc)
-        raise ValueError(f"Unable to read HDF5 file: {path}") from exc
+        raise DataLoadingError(str(path), exc) from exc
     logger.info("Loaded HDF5 dataset '%s' with shape %s from %s", key, data.shape, path)
     return SensorDataset(data)
 
@@ -127,7 +145,7 @@ def stream_data(source: Iterable[object]) -> Generator[SensorDataset, None, None
     for item in source:
         try:
             yield _stream_item_to_dataset(item)
-        except (TypeError, ValueError, KeyError) as exc:
+        except DataExceptError as exc:
             logger.warning("Skipping malformed streaming item %s: %s", item, exc)
             continue
 
@@ -135,11 +153,14 @@ def stream_data(source: Iterable[object]) -> Generator[SensorDataset, None, None
 def _stream_item_to_dataset(item: object) -> SensorDataset:
     """Convert one streaming record into a single-row dataset."""
     if not isinstance(item, Mapping):
-        raise TypeError("Streaming item must be a mapping")
+        raise DataFormatError(["mapping"], type(item).__name__)
 
     timestamp = item.get("timestamp")
     if timestamp is None:
-        raise ValueError("Streaming item missing 'timestamp' field")
+        raise MissingDataError(
+            "timestamp",
+            "Streaming item missing 'timestamp' field",
+        )
 
     timestamp_index = _parse_timestamps([timestamp], "timestamp")
     df = pd.DataFrame([item]).set_index(timestamp_index)

--- a/sensor_modeling/data/loaders.py
+++ b/sensor_modeling/data/loaders.py
@@ -8,15 +8,15 @@ from collections.abc import Generator, Iterable, Mapping
 from os import PathLike
 
 import pandas as pd
-from dataexcept import (
-    DataExceptError,
-    DataFormatError,
-    DataLoadingError,
-    DataValidationError,
-    DependencyError,
-    MissingDataError,
-)
+from dataexcept import DataExceptError
 
+from sensor_modeling.data.exceptions import (
+    SensorDataFormatError,
+    SensorDataLoadingError,
+    SensorDataValidationError,
+    SensorDependencyError,
+    SensorMissingDataError,
+)
 from sensor_modeling.utils.data_io import SensorDataset, read_sensor_csv
 
 logger = logging.getLogger(__name__)
@@ -26,7 +26,7 @@ def _parse_timestamps(values: object, field_name: str) -> pd.Series:
     """Parse timestamp values and reject missing or invalid entries."""
     timestamps = pd.to_datetime(values, errors="coerce")
     if pd.isna(timestamps).any():
-        raise DataValidationError(
+        raise SensorDataValidationError(
             field_name,
             "<invalid timestamp>",
             f"Timestamp field '{field_name}' contains invalid timestamps",
@@ -71,7 +71,8 @@ def load_json(
             records = json.load(f)
     except (OSError, UnicodeError, json.JSONDecodeError) as exc:
         logger.error("Failed to read JSON %s: %s", path, exc)
-        raise DataLoadingError(str(path), exc) from exc
+        legacy = ValueError(f"Unable to read JSON file: {path}")
+        raise SensorDataLoadingError(str(path), legacy) from exc
 
     df = _records_to_frame(records, timestamp_field=timestamp_field)
     logger.info("Loaded JSON with shape %s from %s", df.shape, path)
@@ -81,24 +82,24 @@ def load_json(
 def _records_to_frame(records: object, timestamp_field: str) -> pd.DataFrame:
     """Convert JSON records into a timestamp-indexed DataFrame."""
     if not isinstance(records, list):
-        raise DataFormatError(["JSON list of records"], type(records).__name__)
+        raise SensorDataFormatError(["JSON list of records"], type(records).__name__)
     if any(not isinstance(record, Mapping) for record in records):
-        raise DataFormatError(
+        raise SensorDataFormatError(
             ["JSON list of object records"],
-            "list containing non-object entries",
+            "Invalid JSON structure for tabular data",
         )
 
     try:
         df = pd.DataFrame(records)
     except (TypeError, ValueError) as exc:
         logger.error("JSON structure invalid: %s", exc)
-        raise DataFormatError(
+        raise SensorDataFormatError(
             ["JSON list of object records"],
-            f"invalid tabular structure ({exc})",
+            f"Invalid JSON structure for tabular data ({exc})",
         ) from exc
 
     if timestamp_field not in df.columns:
-        raise MissingDataError(
+        raise SensorMissingDataError(
             timestamp_field,
             f"Timestamp field '{timestamp_field}' missing from JSON records",
         )
@@ -112,12 +113,14 @@ def load_hdf5(path: str | PathLike[str], key: str = "data") -> SensorDataset:
     try:
         import h5py
     except ImportError as exc:  # pragma: no cover - dependency is installed in CI
-        raise DependencyError("h5py", "h5py is required for HDF5 support") from exc
+        raise SensorDependencyError(
+            "h5py", "h5py is required for HDF5 support"
+        ) from exc
 
     try:
         with h5py.File(path, "r") as h5:
             if key not in h5:
-                raise MissingDataError(
+                raise SensorMissingDataError(
                     key,
                     f"Dataset '{key}' not found in HDF5 file",
                 )
@@ -129,7 +132,8 @@ def load_hdf5(path: str | PathLike[str], key: str = "data") -> SensorDataset:
                 )
     except OSError as exc:
         logger.error("Failed to read HDF5 %s: %s", path, exc)
-        raise DataLoadingError(str(path), exc) from exc
+        legacy = ValueError(f"Unable to read HDF5 file: {path}")
+        raise SensorDataLoadingError(str(path), legacy) from exc
     logger.info("Loaded HDF5 dataset '%s' with shape %s from %s", key, data.shape, path)
     return SensorDataset(data)
 
@@ -153,11 +157,11 @@ def stream_data(source: Iterable[object]) -> Generator[SensorDataset, None, None
 def _stream_item_to_dataset(item: object) -> SensorDataset:
     """Convert one streaming record into a single-row dataset."""
     if not isinstance(item, Mapping):
-        raise DataFormatError(["mapping"], type(item).__name__)
+        raise SensorDataFormatError(["mapping"], type(item).__name__)
 
     timestamp = item.get("timestamp")
     if timestamp is None:
-        raise MissingDataError(
+        raise SensorMissingDataError(
             "timestamp",
             "Streaming item missing 'timestamp' field",
         )

--- a/sensor_modeling/utils/data_io.py
+++ b/sensor_modeling/utils/data_io.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+from dataexcept import DataLoadingError, DataValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -28,9 +29,26 @@ def read_sensor_csv(
     - an unnamed first column created by ``DataFrame.to_csv(index=True)``
     - a plain tabular sensor matrix with no timestamp index
     """
-    df = pd.read_csv(path, **kwargs)
+    try:
+        df = pd.read_csv(path, **kwargs)
+    except (
+        OSError,
+        TypeError,
+        UnicodeError,
+        ValueError,
+        pd.errors.ParserError,
+    ) as exc:
+        raise DataLoadingError(str(path), exc) from exc
+
     if timestamp_col in df.columns:
-        df[timestamp_col] = pd.to_datetime(df[timestamp_col])
+        parsed = pd.to_datetime(df[timestamp_col], errors="coerce")
+        if parsed.isna().any():
+            raise DataValidationError(
+                timestamp_col,
+                "<invalid timestamp>",
+                f"Timestamp field '{timestamp_col}' contains invalid timestamps",
+            )
+        df[timestamp_col] = parsed
         return df.set_index(timestamp_col).sort_index()
 
     first_col = df.columns[0] if len(df.columns) else None

--- a/tests/test_dataexcept_ingestion.py
+++ b/tests/test_dataexcept_ingestion.py
@@ -1,0 +1,121 @@
+"""Regression tests for the structured sensor-ingestion exception contract."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+from dataexcept import (
+    DataFormatError,
+    DataLoadingError,
+    DataValidationError,
+    DependencyError,
+    MissingDataError,
+)
+
+from sensor_modeling.data import loaders
+from sensor_modeling.data.exceptions import (
+    SensorDataFormatError,
+    SensorDataLoadingError,
+    SensorDataValidationError,
+    SensorDependencyError,
+    SensorMissingDataError,
+)
+
+
+def test_unreadable_csv_uses_structured_loading_error(tmp_path) -> None:
+    """Missing CSV files should expose DataExcept without breaking ValueError catches."""
+    with pytest.raises(SensorDataLoadingError) as caught:
+        loaders.load_csv(tmp_path / "missing.csv")
+
+    assert isinstance(caught.value, DataLoadingError)
+    assert isinstance(caught.value, ValueError)
+    assert "Unable to read CSV file" in str(caught.value)
+
+
+def test_malformed_json_uses_structured_loading_error(tmp_path) -> None:
+    """JSON decoding failures should be classified as data-loading failures."""
+    path = tmp_path / "malformed.json"
+    path.write_text("{not valid json", encoding="utf-8")
+
+    with pytest.raises(SensorDataLoadingError) as caught:
+        loaders.load_json(path)
+
+    assert isinstance(caught.value, DataLoadingError)
+    assert isinstance(caught.value, ValueError)
+
+
+def test_json_shape_and_required_fields_use_specific_data_errors(tmp_path) -> None:
+    """Payload shape and missing fields should have distinct DataExcept classes."""
+    object_path = tmp_path / "object.json"
+    object_path.write_text(json.dumps({"timestamp": "2024-01-01"}), encoding="utf-8")
+    with pytest.raises(SensorDataFormatError) as malformed:
+        loaders.load_json(object_path)
+    assert isinstance(malformed.value, DataFormatError)
+    assert isinstance(malformed.value, ValueError)
+
+    missing_path = tmp_path / "missing.json"
+    missing_path.write_text(json.dumps([{"sensor_0": 1}]), encoding="utf-8")
+    with pytest.raises(SensorMissingDataError) as missing:
+        loaders.load_json(missing_path)
+    assert isinstance(missing.value, MissingDataError)
+    assert isinstance(missing.value, ValueError)
+
+
+def test_invalid_timestamp_uses_data_validation_error(tmp_path) -> None:
+    """Invalid source timestamps should be data-validation failures."""
+    path = tmp_path / "invalid-timestamp.json"
+    path.write_text(
+        json.dumps([{"timestamp": "not-a-date", "sensor_0": 1}]),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SensorDataValidationError) as caught:
+        loaders.load_json(path)
+
+    assert isinstance(caught.value, DataValidationError)
+    assert isinstance(caught.value, ValueError)
+
+
+def test_hdf5_missing_dataset_uses_missing_data_error(tmp_path) -> None:
+    """Absent HDF5 datasets should be classified separately from file-read failures."""
+    h5py = pytest.importorskip("h5py")
+    path = tmp_path / "data.h5"
+    with h5py.File(path, "w") as h5:
+        h5.create_dataset("other", data=[[1, 0]])
+
+    with pytest.raises(SensorMissingDataError) as caught:
+        loaders.load_hdf5(path)
+
+    assert isinstance(caught.value, MissingDataError)
+    assert isinstance(caught.value, ValueError)
+
+
+def test_hdf5_missing_dependency_uses_dependency_error(monkeypatch, tmp_path) -> None:
+    """Optional dependency failures should remain compatible with ImportError handlers."""
+    monkeypatch.setitem(sys.modules, "h5py", None)
+
+    with pytest.raises(SensorDependencyError) as caught:
+        loaders.load_hdf5(tmp_path / "data.h5")
+
+    assert isinstance(caught.value, DependencyError)
+    assert isinstance(caught.value, ImportError)
+
+
+def test_streaming_bad_records_are_still_skipped() -> None:
+    """Structured record errors should preserve the stream's skip-invalid contract."""
+    stream = [
+        {"timestamp": "2024-01-01 00:00:00", "sensor_0": 1},
+        {"sensor_0": 0},
+        {"timestamp": "not-a-date", "sensor_0": 1},
+        ["not", "a", "mapping"],
+        {"timestamp": "2024-01-01 00:01:00", "sensor_0": 0},
+    ]
+
+    datasets = list(loaders.stream_data(stream))
+
+    assert [dataset.to_dataframe()["sensor_0"].iloc[0] for dataset in datasets] == [
+        1,
+        0,
+    ]


### PR DESCRIPTION
## Summary

Adopt DataExcept for operational failures at the sensor-data ingestion boundary while preserving legacy broad catch behaviour for callers that still use `ValueError` or `ImportError`.

### Scope

- normalize CSV/JSON/HDF5 read failures as `DataLoadingError`;
- classify malformed payload shapes as `DataFormatError`;
- classify missing required timestamp/data fields as `MissingDataError`;
- classify invalid timestamps as `DataValidationError`;
- classify missing HDF5 support as `DependencyError`;
- use the same structured errors for malformed streaming records;
- add sensor-specific compatibility exception types that inherit from DataExcept and the previous builtin exception family;
- add DataExcept `>=1.3,<2.0` as a runtime dependency;
- add focused regression tests for the new taxonomy and compatibility contract.

The integration is deliberately limited to external data and ingestion failures. Model parameters, simulation configuration and other programmer-facing validation continue to use ordinary `ValueError`/`TypeError`.