### PR TITLE
Record the confirmatory study results in the roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -58,13 +58,17 @@ negative. The frozen five-sensor deployment is **not** non-inferior to the
 ten-sensor deployment: it loses 0.1548 balanced accuracy, 95% CI
 [0.1531, 0.1564], against a 0.02 margin — nearly eight times the margin. A
 secondary eight-sensor configuration sits within 0.00529 of the full system
-(0.7405 against 0.7458), so the useful object is a sensor-information frontier
+(0.7405 against 0.7458). These are the frozen study's figures; the 100-seed
+`sensor-modeling ablate` study reported in
+[research questions](docs/RESEARCH_QUESTIONS.md) puts the same two contrasts at
+0.0073 and 0.171 under a different protocol and different seeds, and the two
+sets are not interchangeable. The useful object is a sensor-information frontier
 rather than a winning kit, and only that one kit is settled. All four
 pre-specified sensor interactions are positive.
 
 Two of its other results bear on the sections below. Failure-aware reliability
 weighting is a scoring trade-off rather than a win: it improves log loss by
-0.110 while worsening balanced accuracy by 0.0145, Brier by 0.0157 and
+0.110 while worsening balanced accuracy by 0.0145, Brier by 0.0156 and
 calibration error by 0.0039. And abstention barely moved — mean rates rose only
 from 9.7e-06 to 5.3e-05 as random missingness went from 0% to 40%, so the
 mechanism is effectively silent and hardly responds to losing two fifths of the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,6 +51,33 @@ Three consequences, each documented in
   so no threshold setting repairs it. This is the project's central safety
   claim and it does not currently hold outside the simulator.
 
+The frozen confirmatory simulation also completed since release, at 200 paired
+household trajectories across 40 shards, with its Monte Carlo precision gate met
+(maximum observed MCSE 0.001125 against a 0.002 target). Its headline result is
+negative. The frozen five-sensor deployment is **not** non-inferior to the
+ten-sensor deployment: it loses 0.1548 balanced accuracy, 95% CI
+[0.1531, 0.1564], against a 0.02 margin — nearly eight times the margin. A
+secondary eight-sensor configuration sits within 0.00529 of the full system
+(0.7405 against 0.7458), so the useful object is a sensor-information frontier
+rather than a winning kit, and only that one kit is settled. All four
+pre-specified sensor interactions are positive.
+
+Two of its other results bear on the sections below. Failure-aware reliability
+weighting is a scoring trade-off rather than a win: it improves log loss by
+0.110 while worsening balanced accuracy by 0.0145, Brier by 0.0157 and
+calibration error by 0.0039. And abstention barely moved — mean rates rose only
+from 9.7e-06 to 5.3e-05 as random missingness went from 0% to 40%, so the
+mechanism is effectively silent and hardly responds to losing two fifths of the
+evidence.
+
+**That last result changes the standing of the abstention failure.** It is no
+longer one observation on one kind of data. The mechanism fails in the
+simulator and on real recordings by different routes — near-silence in the
+first, uninformative confidence in the second — which removes the most
+comfortable reading, that it is an artefact of unfamiliar real-world data. All
+confirmatory outcomes remain simulator-derived and are not estimates of field
+performance.
+
 Retained and unchanged: CSV/JSON/HDF5 loading, missing-data handling, Bernoulli
 autoregressive models, HMM variants, NHPP-PELT segmentation, change-point
 detectors, dependency analysis, reporting, the Flask app, and the original CLI.
@@ -150,7 +177,12 @@ the measurement left open, in priority order.
 1. **Reconnect abstention to something informative.** Confidence currently
    inverts above 0.95, most likely because a sticky chain saturates the belief
    during quiet periods: the posterior approaches certainty because no evidence
-   arrived, not because the evidence was strong. Until this is addressed the
+   arrived, not because the evidence was strong. That mechanism remains a
+   hypothesis, but the failure itself is now measured twice over, in the
+   confirmatory simulation and on real recordings, so it cannot be attributed to
+   real-world data alone. RQ2 — can a system fail safely rather than silently —
+   is accordingly answered negatively, its own falsification condition met; see
+   [research questions](docs/RESEARCH_QUESTIONS.md). Until this is addressed the
    project cannot claim a model that knows when it does not know.
 2. **Close the accuracy gap, or establish that this formulation cannot.**
    0.420 against a 0.607 ceiling. Both principled additions tried so far, a
@@ -167,12 +199,19 @@ the measurement left open, in priority order.
    calibration error from 0.312 to 0.202 on unseen homes without moving
    accuracy, so the parameters explain the overconfidence and not the
    discrimination.
-5. **Model the dependency between the occupancy and state layers**, which share
+5. **Re-open sensor selection against the frontier rather than the frozen kit.**
+   The confirmatory study rejected the specific five-sensor deployment
+   decisively, but an eight-sensor configuration came within 0.00529 of the full
+   system while six, three and two sensors lost far more. The reduction question
+   is therefore still open and still worth answering; only the one frozen kit is
+   settled. Any successor kit should be chosen against the frontier and then
+   frozen before scoring, exactly as this one was.
+6. **Model the dependency between the occupancy and state layers**, which share
    evidence and therefore have correlated errors the reported uncertainty does
    not reflect.
-6. **Validate beyond CASAS.** Everything real measured so far comes from one
+7. **Validate beyond CASAS.** Everything real measured so far comes from one
    research group's instrumentation, so it is not 22 or 43 independent studies.
-7. **Reduce the pre-existing type-checking debt** in the older modules and
+8. **Reduce the pre-existing type-checking debt** in the older modules and
    widen the CI `mypy` gate.
 
 ## Near-Term Roadmap
@@ -247,7 +286,12 @@ Planned work:
   correct from incorrect answers by only 0.073 and inverts above 0.95, which no
   aggregate calibration score would have revealed. A diagnostic that reports
   accuracy *within* confidence bands would have caught it.
-- Add model comparison reports with structured machine-readable output.
+- Add model comparison reports with structured machine-readable output. The
+  confirmatory H4 result is the argument for reporting several scores together
+  rather than one: failure-aware weighting improved log loss by 0.110 while
+  worsening balanced accuracy, Brier and calibration error, so any single-metric
+  comparison would have declared it a straight win or a straight loss depending
+  only on which metric was chosen.
 - Add benchmark datasets or synthetic benchmark recipes with fixed seeds.
 
 Quality gates:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -204,8 +204,8 @@ the measurement left open, in priority order.
    accuracy, so the parameters explain the overconfidence and not the
    discrimination.
 5. **Re-open sensor selection against the frontier rather than the frozen kit.**
-   The confirmatory study rejected the specific five-sensor deployment
-   decisively, but an eight-sensor configuration came within 0.00529 of the full
+   The confirmatory study found the specific five-sensor deployment decisively
+   short of the non-inferiority criterion, but an eight-sensor configuration came within 0.00529 of the full
    system while six, three and two sensors lost far more. The reduction question
    is therefore still open and still worth answering; only the one frozen kit is
    settled. Any successor kit should be chosen against the frontier and then

--- a/docs/RESEARCH_QUESTIONS.md
+++ b/docs/RESEARCH_QUESTIONS.md
@@ -49,6 +49,15 @@ accuracy. Fewer sensors cost accuracy and bought honesty about uncertainty.
 Which of those matters more depends on what the output is used for, and that
 is a question this repository can pose but not settle from simulation.
 
+**The frozen confirmatory study agrees in direction, at different values.**
+Its pre-specified 200-trajectory run puts the eight-sensor gap at 0.00529 and
+the five-sensor gap at 0.1548, against 0.0073 and 0.171 above. The figures in
+this section come from the 100-seed `sensor-modeling ablate` study and are not
+interchangeable with the confirmatory ones, which carry the pre-specified
+non-inferiority test: on that test the five-sensor deployment was **rejected**,
+its 95% CI of [0.1531, 0.1564] sitting far outside the 0.02 margin. Both studies
+are simulator-derived. See [ROADMAP.md](../ROADMAP.md).
+
 **Known threat.** The result depends on the simulator's assumed activity
 levels and sensor rates. See `limitations.md`.
 

--- a/docs/RESEARCH_QUESTIONS.md
+++ b/docs/RESEARCH_QUESTIONS.md
@@ -56,7 +56,7 @@ this section come from the 100-seed `sensor-modeling ablate` study and are not
 interchangeable with the confirmatory ones, which carry the pre-specified
 non-inferiority test: on that test the five-sensor deployment was **rejected**,
 its 95% CI of [0.1531, 0.1564] sitting far outside the 0.02 margin. Both studies
-are simulator-derived. See [ROADMAP.md](../ROADMAP.md).
+are simulator-derived. See the [roadmap](roadmap.md).
 
 **Known threat.** The result depends on the simulator's assumed activity
 levels and sensor rates. See `limitations.md`.

--- a/docs/RESEARCH_QUESTIONS.md
+++ b/docs/RESEARCH_QUESTIONS.md
@@ -51,11 +51,12 @@ is a question this repository can pose but not settle from simulation.
 
 **The frozen confirmatory study agrees in direction, at different values.**
 Its pre-specified 200-trajectory run puts the eight-sensor gap at 0.00529 and
-the five-sensor gap at 0.1548, against 0.0073 and 0.171 above. The figures in
-this section come from the 100-seed `sensor-modeling ablate` study and are not
+the five-sensor gap at 0.1548, against 0.0073 and 0.171 above. The preceding
+figures come from the 100-seed `sensor-modeling ablate` study and are not
 interchangeable with the confirmatory ones, which carry the pre-specified
-non-inferiority test: on that test the five-sensor deployment was **rejected**,
-its 95% CI of [0.1531, 0.1564] sitting far outside the 0.02 margin. Both studies
+non-inferiority test: on that test the five-sensor deployment **failed**
+the pre-specified non-inferiority criterion, its 95% CI of [0.1531, 0.1564]
+lying entirely above the 0.02 margin. Both studies
 are simulator-derived. See the [roadmap](roadmap.md).
 
 **Known threat.** The result depends on the simulator's assumed activity


### PR DESCRIPTION
The roadmap was rewritten around the real-data measurement and is accurate on it. But it mentions the frozen confirmatory simulation exactly once, in passing, and never records that the study ran or what it found — even though it completed, passed its gates, and returned a decisively negative headline result.

**Current Baseline** now records it: 200 paired trajectories across 40 shards, MCSE gate met at 0.001125 against a 0.002 target, and the frozen five-sensor deployment rejected as non-inferior by 0.1548 (95% CI [0.1531, 0.1564]) against a 0.02 margin — nearly eight times the margin. An eight-sensor configuration sits within 0.00529 of the full system.

**The result that changes something.** The confirmatory study's abstention outcome — mean rates rising only from 9.7e-06 to 5.3e-05 as missingness went from 0% to 40% — means the abstention failure is no longer a single observation on one kind of data. It fails in the simulator and on real recordings by different routes: near-silence in the first, uninformative confidence in the second. That removes the most comfortable reading, that it is an artefact of unfamiliar real-world data. Item 1 of the research list is updated to say so, keeping the sticky-chain mechanism marked as the hypothesis it still is, and noting RQ2 is now formally answered negatively.

**Sensor selection is re-opened, not closed.** Added as item 5. The H2 rejection settles one kit, not the question: eight sensors came within 0.00529 of ten while six, three and two lost far more. A successor kit should be chosen against the frontier and frozen before scoring, as this one was.

**H4 gets a use.** Failure-aware weighting improved log loss by 0.110 while worsening balanced accuracy, Brier and calibration error. That is the concrete argument for the 0.4.0 multi-metric comparison work — a single-metric comparison would have called it a win or a loss depending only on which metric was picked.

Every figure was read from `accepted_summary.json`, including recomputing the 0.00529 and 0.1548 gaps from the per-configuration balanced accuracies rather than copying them from the manuscript. Docs-only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records the frozen confirmatory simulation’s results in the roadmap and research questions, so the study is no longer mentioned only in passing and its outcomes now update the research questions. No code changes; docs only.

- Documents the 200-trajectory, 40-shard run: the MCSE gate passed at 0.001125 against a 0.002 target, and the five-sensor deployment failed the pre-specified non-inferiority test with a 0.1548 balanced-accuracy loss (95% CI [0.1531, 0.1564]) against a 0.02 margin; the eight-sensor configuration is 0.00529 behind the full system.
- Keeps these confirmatory figures distinct from the 100-seed `sensor-modeling ablate` results (0.0073 and 0.171) and notes both are simulator-derived.
- Answers RQ2 negatively: abstention now demonstrably fails in both the simulator and real recordings by different routes, while the sticky-chain mechanism remains a hypothesis.
- Reopens sensor selection around an information frontier and uses the H4 scoring trade-off (log loss improves by 0.110; balanced accuracy, Brier, and calibration error worsen) to justify multi-metric comparison reports.
- Links the research questions doc to the roadmap.

<sup>Written for commit 6f82c519735a6f5007c57b5bb4d4c388528af8ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

