### PR TITLE
fix: preserve CSV DataExcept compatibility

### DIFF
--- a/sensor_modeling/data/__init__.py
+++ b/sensor_modeling/data/__init__.py
@@ -1,5 +1,22 @@
 """Data loading, preprocessing, validation, and simulation utilities."""
 
-from . import loaders, preprocessing, synthetic, validation
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from . import loaders, preprocessing, synthetic, validation
 
 __all__ = ["loaders", "preprocessing", "validation", "synthetic"]
+
+
+def __getattr__(name: str) -> ModuleType:
+    """Lazily import public data submodules to avoid ingestion import cycles."""
+    if name not in __all__:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = import_module(f"{__name__}.{name}")
+    globals()[name] = module
+    return module

--- a/sensor_modeling/utils/data_io.py
+++ b/sensor_modeling/utils/data_io.py
@@ -11,7 +11,11 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-from dataexcept import DataLoadingError, DataValidationError
+
+from sensor_modeling.data.exceptions import (
+    SensorDataLoadingError,
+    SensorDataValidationError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -38,12 +42,13 @@ def read_sensor_csv(
         ValueError,
         pd.errors.ParserError,
     ) as exc:
-        raise DataLoadingError(str(path), exc) from exc
+        legacy = ValueError(f"Unable to read CSV file: {path}")
+        raise SensorDataLoadingError(str(path), legacy) from exc
 
     if timestamp_col in df.columns:
         parsed = pd.to_datetime(df[timestamp_col], errors="coerce")
         if parsed.isna().any():
-            raise DataValidationError(
+            raise SensorDataValidationError(
                 timestamp_col,
                 "<invalid timestamp>",
                 f"Timestamp field '{timestamp_col}' contains invalid timestamps",

--- a/tests/test_dataexcept_ingestion.py
+++ b/tests/test_dataexcept_ingestion.py
@@ -22,6 +22,7 @@ from sensor_modeling.data.exceptions import (
     SensorDependencyError,
     SensorMissingDataError,
 )
+from sensor_modeling.utils.data_io import SensorDataset
 
 
 def test_unreadable_csv_uses_structured_loading_error(tmp_path) -> None:
@@ -32,6 +33,28 @@ def test_unreadable_csv_uses_structured_loading_error(tmp_path) -> None:
     assert isinstance(caught.value, DataLoadingError)
     assert isinstance(caught.value, ValueError)
     assert "Unable to read CSV file" in str(caught.value)
+
+
+def test_sensor_dataset_from_csv_preserves_loading_compatibility(tmp_path) -> None:
+    """The direct CSV constructor should expose the same compatibility contract."""
+    with pytest.raises(SensorDataLoadingError) as caught:
+        SensorDataset.from_csv(tmp_path / "missing.csv")
+
+    assert isinstance(caught.value, DataLoadingError)
+    assert isinstance(caught.value, ValueError)
+    assert "Unable to read CSV file" in str(caught.value)
+
+
+def test_sensor_dataset_from_csv_preserves_timestamp_compatibility(tmp_path) -> None:
+    """CSV timestamp validation should remain catchable as legacy ValueError."""
+    path = tmp_path / "invalid-timestamp.csv"
+    path.write_text("timestamp,sensor_0\nnot-a-date,1\n", encoding="utf-8")
+
+    with pytest.raises(SensorDataValidationError) as caught:
+        SensorDataset.from_csv(path)
+
+    assert isinstance(caught.value, DataValidationError)
+    assert isinstance(caught.value, ValueError)
 
 
 def test_malformed_json_uses_structured_loading_error(tmp_path) -> None:


### PR DESCRIPTION
## Summary

Follow up on #150 by making the direct CSV path use the same sensor-specific compatibility exceptions as the public loaders.

### Fixes

- `read_sensor_csv()` now raises `SensorDataLoadingError` rather than the generic `DataLoadingError`;
- invalid named CSV timestamps now raise `SensorDataValidationError` rather than the generic `DataValidationError`;
- `SensorDataset.from_csv()` therefore preserves both the structured DataExcept taxonomy and legacy `ValueError` catches;
- regression tests cover missing files and invalid timestamps through the direct constructor.

This keeps the compatibility guarantee from #150 consistent across both CSV entry points.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the DataExcept compatibility contract for the direct CSV loading path in `SensorDataset.from_csv()` so both CSV entry points raise the same sensor-specific exceptions. Also switches the `sensor_modeling.data` package to lazy submodule imports to avoid circular import cycles.

- `read_sensor_csv()` now raises `SensorDataLoadingError` and `SensorDataValidationError` instead of the generic `DataLoadingError` and `DataValidationError`.
- The new exceptions still inherit from the generic ones and from `ValueError`, so existing catch blocks keep working.
- Added regression tests covering missing files and invalid timestamps through `SensorDataset.from_csv()`.

<sup>Written for commit ffd8e75e29512efaae931e75bfd2d0d2c19afe87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

