### PR TITLE
Record the measured abstention behaviour in the design docs

### DIFF
--- a/docs/MULTIMODAL_ARCHITECTURE.md
+++ b/docs/MULTIMODAL_ARCHITECTURE.md
@@ -154,6 +154,12 @@ ignore the new packages entirely.
 | 7 | Simulation | Generative process independent of the estimator, enforced by test | Met |
 | 8 | Evaluation and ablation | Paired design structural; unpaired series refused | Met |
 | 9 | Online pipeline | Bounded memory; snapshot/restore round-trips through JSON | Met |
+
+These are delivery conditions, not empirical validation. Stage 3's criterion is
+that abstention is *available*, and it is implemented and wired in, so the stage
+is met as specified. Whether abstention is *informative* is a separate question,
+and on the evidence available the answer is no — see the measured behaviour in
+[uncertainty model](UNCERTAINTY_MODEL.md) and [real data](real_data.md).
 | 10 | Interoperability | Measurements and inferences distinguishable by provenance | Met |
 
 ## 6. Architectural risks

--- a/docs/UNCERTAINTY_MODEL.md
+++ b/docs/UNCERTAINTY_MODEL.md
@@ -126,6 +126,18 @@ evidence to be ambiguous about.
 an abstention, not an eighth behaviour, and `StateOntology` rejects any attempt
 to include it.
 
+**Measured behaviour: this mechanism does not currently work.** The rule above
+is what is implemented, not a description of behaviour that has been validated.
+Over 60,948 scored steps on real recordings, stated confidence separated correct
+from incorrect answers by only 0.073, and the 0.95–1.00 confidence band was
+*less* accurate at 0.561 than the 0.85–0.95 band at 0.653 while covering 39% of
+steps. Raising `min_confidence` therefore discards the better band and keeps the
+saturated one, so no threshold setting repairs it. The frozen confirmatory
+simulation fails from the other direction: mean abstention rose only from
+9.7e-06 to 5.3e-05 as random missingness went from 0% to 40%, so the mechanism
+barely fires at all. Treat `min_confidence` and `min_completeness` as
+unvalidated. See [real data](real_data.md).
+
 ### 7. Baseline
 
 Daily features are accumulated from the posterior:


### PR DESCRIPTION
Continuing the sweep that found RQ1 and RQ2 stale, into the two design documents that specify abstention. Both were silent about a mechanism the project has now measured twice and found not to work.

**`UNCERTAINTY_MODEL.md` section 6** is the specification for abstention — the two trigger conditions, why they are separate, and how `UNKNOWN` is kept out of the state vector. It carries no empirical status at all, so someone implementing or tuning against it would have no way to know the mechanism fails. It now says so directly, with the figures: confidence separating correct from incorrect answers by 0.073 over 60,948 scored steps, the 0.95–1.00 band less accurate at 0.561 than the 0.85–0.95 band at 0.653 while covering 39% of steps, and the confirmatory simulation failing from the other direction at 9.7e-06 to 5.3e-05 across 0–40% missingness. `min_confidence` and `min_completeness` are labelled unvalidated, which is the practical consequence for anyone touching them.

**`MULTIMODAL_ARCHITECTURE.md` stage 3 is left marked Met, deliberately.** Its acceptance criterion is that abstention is *available*, and the mechanism is implemented and wired in, so the stage is met exactly as specified — changing the verdict would misstate the criterion rather than correct it. What was missing is that a reader scanning nine rows of `Met` gets no hint that one delivered component does not function. A note under the table now distinguishes delivery conditions from empirical validation and points at the measurement.

Provenance checked rather than recalled: the 0.073 and per-band figures come from 60,948 steps across five homes per `real_data.md`, so the text says "on real recordings" rather than attributing them to the 22-home panel, which is a different scope. The confirmatory values were read from `accepted_summary.json` (9.6784e-06 and 5.2859e-05).

`mkdocs build --strict` run locally: builds clean, both new cross-links resolve inside the docs tree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the two design docs that specify abstention to record that the mechanism has been measured twice and found not to work.

- `UNCERTAINTY_MODEL.md` now states the measured failure directly and labels `min_confidence` and `min_completeness` unvalidated.
- `MULTIMODAL_ARCHITECTURE.md` keeps stage 3 marked Met since its criterion is availability, but adds a note distinguishing delivery from empirical validation.

<sup>Written for commit b83e86562bd81e81c960d34655b34ef9fbfe9a31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

