### PR TITLE
Verify tracked artifact digests independently of line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# The frozen v0.3 artifacts carry recorded SHA-256 digests computed on LF
+# content. Letting git rewrite their line endings on checkout would make those
+# digests verify or fail depending on the platform rather than on the content.
+artifacts/v03/*.json text eol=lf

--- a/docs/EXTERNAL_COHORT_COMPOSITION.md
+++ b/docs/EXTERNAL_COHORT_COMPOSITION.md
@@ -57,3 +57,25 @@ exactly the post-hoc selection the one-shot design exists to prevent.
 This page is a statement about interpretation, written before the outcome is
 known, so that a disappointing result is read carefully rather than explained
 away afterwards.
+
+## A known discrepancy in the recorded registry digest
+
+The frozen manifest records `source.registry_sha256` as
+`d5f0c1086ba06cbf095206019a3cff2bebfd6cedf09ecd6b496d703443393066`. Recomputing
+it from `artifacts/v03/casas_v1_resident_registry.json` as stored in the
+repository gives
+`2876c648a696baa8bf5f5ef5fed06cca2288113105919699e401ea7fad1a0ba1`.
+
+The registry has not changed. The two values are the same content with different
+line endings: the recorded digest was computed from a Windows working copy whose
+checkout had converted LF to CRLF, and the repository stores the file with LF.
+`build_external_cohort_manifest.py` now normalises line endings before hashing,
+so a rebuild would record the LF value, but the frozen manifest is left exactly
+as it was — editing it would change `manifest_sha256` and invalidate the freeze
+declaration that records it.
+
+This digest is recorded provenance and is not verified at scoring time, so it
+gates nothing. It is documented here because an auditor recomputing it would
+otherwise find a mismatch and reasonably suspect the registry had been altered.
+The cohort membership was determined by the registry's content, which is
+unaffected.

--- a/scripts/build_external_cohort_manifest.py
+++ b/scripts/build_external_cohort_manifest.py
@@ -72,6 +72,17 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def _text_sha256(path: Path) -> str:
+    """Digest of a tracked text file, independent of checkout line endings.
+
+    Git rewrites line endings on checkout for platforms that ask for CRLF, so
+    hashing raw bytes records where the file was cloned rather than what it
+    says. Use this for repository artifacts; keep :func:`_sha256` for archive
+    data, whose bytes are meant to be exactly as distributed.
+    """
+    return hashlib.sha256(path.read_bytes().replace(b"\r\n", b"\n")).hexdigest()
+
+
 def screen(
     path: Path,
     zone: ZoneInfo,
@@ -176,7 +187,7 @@ def main() -> None:
             "record": args.source_record,
             "resident_counts": "artifacts/v03/casas_v1_resident_registry.json",
             "registry_source": registry_source,
-            "registry_sha256": _sha256(args.registry),
+            "registry_sha256": _text_sha256(args.registry),
         },
         "criteria": {
             "outside_development_panel": True,

--- a/scripts/score_v03_external.py
+++ b/scripts/score_v03_external.py
@@ -98,6 +98,23 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def _text_sha256(path: Path) -> str:
+    """Digest of a tracked text file, independent of checkout line endings.
+
+    The frozen manifest digest was computed on LF content. Git rewrites line
+    endings on checkout for platforms that ask for CRLF, so hashing the raw
+    bytes makes verification depend on where the repository was cloned rather
+    than on what the file says. That turns a genuine integrity check into a
+    platform check: it passes in Linux CI and refuses on a Windows working
+    copy whose manifest is byte-identical once normalised. Normalising first
+    keeps the recorded digest valid everywhere.
+
+    Only for files git may rewrite. Archive data and result files are hashed
+    with :func:`_sha256`, where every byte is meant to be exactly as written.
+    """
+    return hashlib.sha256(path.read_bytes().replace(b"\r\n", b"\n")).hexdigest()
+
+
 def _canonical_fit_sha256(fit: dict[str, Any]) -> str:
     """Digest of the fit block, matching the freeze validator byte for byte."""
     payload = json.dumps(
@@ -143,7 +160,7 @@ def load_cohort(path: Path, declaration: Path) -> list[dict[str, Any]]:
         raise SystemExit(f"freeze declaration not found at {declaration}")
     freeze = json.loads(declaration.read_text(encoding="utf-8"))
     expected = freeze.get("manifest_sha256")
-    actual = _sha256(path)
+    actual = _text_sha256(path)
     if expected != actual:
         raise SystemExit(
             f"cohort manifest digest mismatch: declaration records {expected}, "


### PR DESCRIPTION
The one-shot external scoring refused to run, correctly, and the cause was a defect in the guard rather than a broken freeze.

`score_v03_external.py` verifies the cohort manifest against the digest in the freeze declaration by hashing raw bytes. Both artifacts are stored in git with LF; a Windows checkout converts them to CRLF. The manifest on disk is byte-identical to the frozen one once normalised — its LF digest is exactly the `6e3e157…` the declaration records — but the raw-byte digest differs, so the check refused valid data with "the frozen cohort has changed".

That made an integrity check into a platform check: it passes in Linux CI and fails on a Windows working copy holding identical content. The profile digest in the same run passed, because it uses canonical JSON. I used the right approach for one artifact and the wrong one for the other in the same file — this was the verification added in response to the earlier "unverified cohort manifest" review finding, so the hole was closed in a way that only worked where CI runs.

**Fix.** A `_text_sha256` helper normalising CRLF to LF before hashing, used only for repository artifacts that git may rewrite. Archive data and result files keep raw-byte `_sha256`, where every byte is meant to be exactly as distributed. The recorded digest is unchanged and still valid: `6e3e157…` *is* the LF digest. A `.gitattributes` pins `artifacts/v03/*.json` to `eol=lf` so future checkouts do not reintroduce it.

**Second instance.** `build_external_cohort_manifest.py` hashes the git-tracked resident registry the same way; fixed with the same helper. `validate_v03_profile_freeze.py` was already correct — it uses canonical JSON.

**A discrepancy found while checking that, documented rather than edited.** The frozen manifest records `registry_sha256` as the CRLF digest of the registry, not the LF one stored in git, which means that script was originally run from a Windows checkout. The registry is unchanged — same content, different line endings — and the field is written but never verified, so it gates nothing and cohort membership is unaffected. I did not correct it in the manifest: editing a frozen artifact would change `manifest_sha256` and invalidate the declaration recording it. `EXTERNAL_COHORT_COMPOSITION.md` now carries both digests and the explanation, so an auditor recomputing it finds the answer instead of suspecting tampering.

The one shot was not spent: the guard refuses before any home is read, and no result or consumed marker was written.

Checks: 910 tests pass locally, `ruff check` clean, `ruff format` applied, and the manifest digest re-verified against the declaration after formatting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes digest verification for git-tracked artifacts so the frozen cohort check no longer fails on Windows checkouts.

Previously, `score_v03_external.py` hashed the cohort manifest’s raw bytes, so a Windows checkout (CRLF) produced a different digest than Linux CI (LF) and rejected valid data as "the frozen cohort has changed". Now both that script and `build_external_cohort_manifest.py` normalize CRLF to LF before hashing tracked text files via a shared `_text_sha256` helper. Archive data and result files keep raw-byte hashing. A new `.gitattributes` pins `artifacts/v03/*.json` to `eol=lf` so future checkouts stay consistent.

**Documented discrepancy**

- The frozen manifest records `registry_sha256` as the CRLF digest of the registry, while the repo stores LF content; the registry is unchanged, and the field is never verified.
- The docs now explain the mismatch and provide both digests, so auditors won’t suspect tampering.

<sup>Written for commit b61bc808d7f5b246ddffa67c62ff3093e943b254. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/behavioral-sensing-research/pull/156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

